### PR TITLE
Tags dans les templates de courrier + critères de recherches dans msPeopleSearch::getSimpleSearchPeople()

### DIFF
--- a/class/msPDF.php
+++ b/class/msPDF.php
@@ -387,6 +387,11 @@ class msPDF
             //si c'est un courrier
             if ($this->_type=='courrier') {
 
+              // permet de charger les tags page.courrier dans les template twig
+              $courrier = new msCourrier();
+              $courrier->setPatientID($this->_toID);
+              $this->_courrierData=$courrier->getCourrierData();
+
               //on déclare le modèle de page
               if (!isset($this->_pageHeader)) {
                   $this->_pageHeader = $this->makeWithTwig($p['config']['templateCourrierHeadAndFoot']);

--- a/class/msPeopleSearch.php
+++ b/class/msPeopleSearch.php
@@ -292,7 +292,11 @@ class msPeopleSearch
         $final=array_slice($final, $this->_limitStart, $this->_limitNumber, true);
 
         foreach ($final as $k=>$v) {
-            if ($v > 1) {
+            // number of criteria requided for matching this people
+            $nbforvalid = count($data)-1;
+            // lastname and birthname count for the same criteria
+            if(!empty($data['lastname']) && !empty($data['birthname'])) $nbforvalid--;
+            if ($v > $nbforvalid) {
                 $patient= new msPeople();
                 $patient->setToID($k);
                 $peopleType = $patient->getPeopleType();


### PR DESCRIPTION
En espérant que se soit correcte (je suis pas encore bien familier avec le code MedShakeEHR) voici deux proposition de correctifs : 

* Actuellement il n'est pas possible de filtrer précisément les recherches en utilisant `msPeopleSearch::getSimpleSearchPeople()` car la méthode retournera un résultat du moment qu'un seul des critère de recherche est trouvé. Avec la modification proposé la méthode retournera un résultat en fonction du nombre de critère de recherche utilisé.

* La seconde modification permet de récupérer les tags `page.courrier` dans les template twig pour générer le pdf d'un courrier.
