### PR TITLE
feat: ajout date de naissance pour recherche vital

### DIFF
--- a/public_html/js/rechercher.js
+++ b/public_html/js/rechercher.js
@@ -98,19 +98,26 @@ $(document).ready(function() {
     $('#lectureCpsVitale').modal('hide');
     indexVitale = $(this).attr('data-indexVitale');
 
+    // TODO utiliser le NIR bénéficiaire (chmap [104][9]) par default pour la recheche si fournis ?
+    //$('#autreCrit').val('nss');
+
     dataVitale[indexVitale]['firstname'] = ucfirst(dataVitale[indexVitale]['firstname']);
     //$('#autreCritVal').val(dataVitale[indexVitale]['nss']);
     if(dataVitale[indexVitale]['birthname'] && dataVitale[indexVitale]['lastname']) {
       $('#formRecherchePatients input[name="lastname"]').val(dataVitale[indexVitale]['lastname']);
     } else if (dataVitale[indexVitale]['birthname']) {
-      console.log($('input[name="lastname"]'));
       $('#formRecherchePatients input[name="lastname"]').val(dataVitale[indexVitale]['birthname']);
     } else if (dataVitale[indexVitale]['lastname']) {
       $('#formRecherchePatients input[name="lastname"]').val(dataVitale[indexVitale]['lastname']);
     }
     $('#formRecherchePatients input[name="firstname"]').val(dataVitale[indexVitale]['firstname']);
 
-    //$('#autreCrit').val('nss');
+    // Si la date de naissance est fournis l'utiliser aussi comme critaire de recherche
+    if (dataVitale[indexVitale]['birthdate']) {
+      $('#formRecherchePatients input[name="autre"]').val(dataVitale[indexVitale]['birthdate']);
+      $('#formRecherchePatients select[name="autre"]').val('birthdate');
+    }
+
     $('#autreCritVal').trigger('keyup');
 
   });


### PR DESCRIPTION
Simple ajout de la date de naissance du patient à la recherche au moment de la lecture de la carte vital via VitalOnline.

Permet de mieux différentier les homonymes.