### PR TITLE
add: .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+
+# PHP PSR-2 Coding Standards
+# http://www.php-fig.org/psr/psr-2/
+[*.php]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+[*.js]
+indent_style = tab
+[*.css]
+indent_style = tab
+[*.xml]
+indent_style = tab
+[*.md]
+trim_trailing_whitespace = false
+
+# Somes files in medshakeEHR are indented with 2 space
+[public_html/install.php]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Simple ajout d'un fichier pour [EditorConfig](https://editorconfig.org/) afin d'aider à normer le style de codage entre plusieurs éditeurs.