### PR TITLE
fix(): overflow sur la liste des patients du jour

### DIFF
--- a/public_html/js/general.js
+++ b/public_html/js/general.js
@@ -350,6 +350,12 @@ $(document).ready(function() {
     $('.QRcodeAccesPhoneCapture').html(el);
   }
 
+	// Évite que la liste ne dépasse l'écran quant la page est redimentionner
+	$(window).on('resize', function(){
+    $('#patientsOfTheDayMenu div.dropdown-menu').height(window.innerHeight*0.75);
+	});
+	$('#patientsOfTheDayMenu div.dropdown-menu').height(window.innerHeight*0.75);
+
 });
 
 

--- a/templates/base/pageTopNavbar.html.twig
+++ b/templates/base/pageTopNavbar.html.twig
@@ -104,7 +104,7 @@
                 Aujourd'hui
               {% endif %}
             </a>
-            <div class="dropdown-menu">
+            <div class="dropdown-menu" style="overflow-y:scroll">
               {% include('pageTopNavbarPatientsOfTheDay.html.twig') %}
             </div>
           </li>


### PR DESCRIPTION
Pour les grosse journée ou sur les petits écran, la liste *patients of the day* dépasse de l'écran ce qui empêche de voire les dernières entrées.

Ajoute une attribut `overflow-y` au `<div>` conteneur de la liste et change automatiquement sa auteur quant le fenêtre est redimensionné.