### PR TITLE
fix: msPDF permet de récupérer AuteurInitial et UtilisateurActif dans les template de courrier

### DIFF
--- a/class/msCourrier.php
+++ b/class/msCourrier.php
@@ -364,6 +364,16 @@ class msCourrier
         }
         $tabRetour['patientID']=$this->_patientID;
 
+		// data de l'auteur initial si l'objet existe
+        if (is_numeric($this->_objetID)) {
+			$this->_getObjetData();
+			$tabRetour=$tabRetour+$this->_getPsData($this->_objetData['fromID'],'AuteurInitial_');
+        }
+		// ou sinon l'auteur initial est l'utilisateur actif
+		else if (is_numeric($this->_fromID)) {
+			$tabRetour=$tabRetour+$this->_getPsData($this->_fromID, 'AuteurInitial_');
+		}
+
         //data utilisateur courant
         if(isset($this->_fromID)) {
           $tabRetour=$tabRetour+$this->_getPsData($this->_fromID,'UtilisateurActif_');

--- a/class/msCourrier.php
+++ b/class/msCourrier.php
@@ -365,10 +365,10 @@ class msCourrier
         $tabRetour['patientID']=$this->_patientID;
 
 		// data de l'auteur initial si l'objet existe
-        if (is_numeric($this->_objetID)) {
+        	if (is_numeric($this->_objetID)) {
 			$this->_getObjetData();
 			$tabRetour=$tabRetour+$this->_getPsData($this->_objetData['fromID'],'AuteurInitial_');
-        }
+        	}
 		// ou sinon l'auteur initial est l'utilisateur actif
 		else if (is_numeric($this->_fromID)) {
 			$tabRetour=$tabRetour+$this->_getPsData($this->_fromID, 'AuteurInitial_');

--- a/class/msPDF.php
+++ b/class/msPDF.php
@@ -390,6 +390,8 @@ class msPDF
               // permet de charger les tags page.courrier dans les template twig
               $courrier = new msCourrier();
               $courrier->setPatientID($this->_toID);
+			  $courrier->setFromID($this->_fromID);
+			  if (!empty($this->_objetID)) $courrier->setObjetID($this->_objetID);
               $this->_courrierData=$courrier->getCourrierData();
 
               //on déclare le modèle de page

--- a/class/msPDF.php
+++ b/class/msPDF.php
@@ -387,6 +387,11 @@ class msPDF
             //si c'est un courrier
             if ($this->_type=='courrier') {
 
+              // permet de charger les tags page.courrier dans les template twig
+              $courrier = new msCourrier();
+              $courrier->setPatientID($this->_toID);
+              $this->_courrierData=$courrier->getCourrierData();
+
               //on déclare le modèle de page
               if (!isset($this->_pageHeader)) {
                   $this->_pageHeader = $this->makeWithTwig($p['config']['templateCourrierHeadAndFoot']);

--- a/class/msPDF.php
+++ b/class/msPDF.php
@@ -390,8 +390,8 @@ class msPDF
               // permet de charger les tags page.courrier dans les template twig
               $courrier = new msCourrier();
               $courrier->setPatientID($this->_toID);
-			  $courrier->setFromID($this->_fromID);
-			  if (!empty($this->_objetID)) $courrier->setObjetID($this->_objetID);
+	      $courrier->setFromID($this->_fromID);
+	      if (!empty($this->_objetID)) $courrier->setObjetID($this->_objetID);
               $this->_courrierData=$courrier->getCourrierData();
 
               //on déclare le modèle de page

--- a/templates/models4printAuto/base-page-closeHtml.html.twig
+++ b/templates/models4printAuto/base-page-closeHtml.html.twig
@@ -1,0 +1,32 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : le bas de page qui referme le html
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+</div>
+<!-- stop body -->
+<!-- Le texte du footer est dans le header !  -->
+</body>
+</html>

--- a/templates/models4printAuto/base-page-headAndFoot.html.twig
+++ b/templates/models4printAuto/base-page-headAndFoot.html.twig
@@ -1,0 +1,121 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : page avec header et footer
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+
+    <html>
+        <head>
+            <style>
+                @page {
+                    margin: 190pt 50pt 100pt;
+                    font-family: Helvetica;
+                }
+                #header {
+                    position: fixed;
+                    left: 0;
+                    top: -160pt;
+                    right: 0;
+                    height: 150pt;
+                    margin-bottom: 40pt;
+                    border-bottom: 1pt solid #777;
+                }
+                #footer {
+                    position: fixed;
+                    left: 0;
+                    bottom: -110pt;
+                    right: 0;
+                    height: 120pt;
+                    font-size: 8pt;
+                    padding-top: 10pt;
+                    border-top: 1pt solid #777;
+                }
+
+                #footer .barrecode {
+                    display: inline-block;
+                    width: 50%;
+                    text-align: center;
+                }
+
+                #footer .mentions {
+                  display: block;
+                  width: 100%;
+                  text-align: center;
+                }
+
+                .gras {
+                    font-weight: bold;
+                }
+                .centrer {
+                  text-align : center;
+                }
+                .t6 {
+                  font-size : 6pt;
+                }
+                .t8 {
+                  font-size : 8pt;
+                }
+                .t9 {
+                  font-size : 9pt;
+                }
+                .t10 {
+                  font-size : 10pt;
+                }
+                .t12 {
+                  font-size : 12pt;
+                }
+
+            </style>
+            <body>
+
+            {% set tag = page.courrier %}
+
+            <div id="header">
+                <div class="t8" style="display : inline-block; width : 65%;vertical-align : bottom;">
+                    <span class="gras" style="font-size : 16pt;">{{ tag.AuteurInitial_identiteUsuelleTitre	}}</span><br>
+                    Médecin généraliste - Conventionnée secteur 1<br><br>
+
+                    N°ADELI : {{ tag.AuteurInitial_adeli }} <br>
+                    RPPS : {{ tag.AuteurInitial_rpps }} <br>
+                </div>
+
+                <div class="t8" style=" display : inline-block; width : 35%; vertical-align : bottom; text-align : center;padding-top : 88pt;">
+                    {{ tag.AuteurInitial_etablissementAdressePro }}<br>
+                    {{ tag.AuteurInitial_adresseProLigne1 }}<br>
+                    {{ tag.AuteurInitial_adresseProLigne2 }}<br>
+                    Consultations sur RDV : {{ tag.AuteurInitial_telPro }}<br>
+                    En cas d’urgence, composez le 15
+                </div>
+            </div>
+            <div id="footer">
+                  <p class="barrecode">RPPS<br><img src="/{{ config.urlHostSuffixe }}/{{ config.stockageLocation }}barecode/barecode-rpps-{{ tag.AuteurInitial_rpps  }}.svg" style="width : 130px; height : 40px"><figcaption>{{ tag.AuteurInitial_rpps  }}</figcaption></p>
+                  <p class="barrecode">ADELI<br><img src="/{{ config.urlHostSuffixe }}/{{ config.stockageLocation }}barecode/barecode-adeli-{{ tag.AuteurInitial_adeli  }}.svg" style="width : 130px; height : 40px"><figcaption>{{ tag.AuteurInitial_adeli  }}</figcaption></p>
+                  <!--
+                       <p class="mentions">Membre d’une AGA, règlement par chèque accepté.</p>
+                  -->
+            </div>
+
+            <!-- stop head -->
+            <div class="t9">

--- a/templates/models4printAuto/base-page-headAndNoFoot.html.twig
+++ b/templates/models4printAuto/base-page-headAndNoFoot.html.twig
@@ -1,0 +1,111 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : page avec header mais SANS footer
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+
+    <html>
+        <head>
+            <style>
+                @page {
+                    margin: 170pt 50pt 40pt 50pt;
+                    font-family: Helvetica;
+                }
+                #header {
+                    position: fixed;
+                    left: 0;
+                    top: -150pt;
+                    right: 0;
+                    height: 140pt;
+                    margin-bottom: 40pt;
+                    border-bottom: 1pt solid #777;
+                }
+
+                h2 {
+                  margin-top : 4pt;
+                }
+
+                h3 {
+                  margin : 12pt 0 5pt 0;
+                  padding : 0;
+                }
+
+                h4 {
+                  margin : 10pt 0 3pt 0;
+                  padding : 0;
+                }
+
+                ul {
+                  margin : 0 0 0 10pt;
+                  padding : 0;
+                }
+
+                .gras {
+                    font-weight: bold;
+                }
+                .centrer {
+                  text-align : center;
+                }
+                .t6 {
+                  font-size : 6pt;
+                }
+                .t8 {
+                  font-size : 8pt;
+                }
+                .t9 {
+                  font-size : 9pt;
+                }
+                .t10 {
+                  font-size : 10pt;
+                }
+                .t12 {
+                  font-size : 12pt;
+                }
+
+            </style>
+            <body>
+
+                {% set tag = page.courrier %}
+
+                <div id="header">
+                  <div class="t8" style="display : inline-block; width : 65%;vertical-align : bottom;">
+                      <span class="gras" style="font-size : 16pt;">{{ tag.AuteurInitial_identiteUsuelleTitre	}}</span><br>
+                      Conventionnée secteur 1<br><br>
+
+                      N°ADELI : {{ tag.AuteurInitial_adeli }} <br>
+                      RPPS : {{ tag.AuteurInitial_rpps }} <br>
+                  </div>
+
+                  <div class="t8" style=" display : inline-block; width : 35%; vertical-align : bottom; text-align : center;padding-top : 88pt;">
+                      {{ tag.AuteurInitial_etablissementAdressePro }}<br>
+                      {{ tag.AuteurInitial_adresseProLigne1 }}<br>
+                      {{ tag.AuteurInitial_adresseProLigne2 }}<br>
+                      Consultations sur RDV : {{ tag.AuteurInitial_telPro }}<br>
+                      En cas d’urgence, composez le 15
+                  </div>
+                </div>
+
+                <!-- stop head -->
+                <div class="t9">

--- a/templates/models4printAuto/base-page-noHeadAndNoFoot.html.twig
+++ b/templates/models4printAuto/base-page-noHeadAndNoFoot.html.twig
@@ -1,0 +1,85 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : page SANS header et SANS footer
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+
+  <html>
+    <head>
+      <style>
+        @page {
+          margin: 40pt 50pt;
+          font-family: Helvetica;
+        }
+
+        h2 {
+          margin-top: 4pt;
+        }
+
+        h3 {
+          margin: 12pt 0 5pt;
+          padding: 0;
+        }
+
+        h4 {
+          margin: 10pt 0 3pt;
+          padding: 0;
+        }
+
+        ul {
+          margin: 0 0 0 10pt;
+          padding: 0;
+        }
+
+        .gras {
+          font-weight: bold;
+        }
+        .centrer {
+          text-align: center;
+        }
+        .t6 {
+          font-size: 6pt;
+        }
+        .t8 {
+          font-size: 8pt;
+        }
+        .t9 {
+          font-size: 9pt;
+        }
+        .t10 {
+          font-size: 10pt;
+        }
+        .t12 {
+          font-size: 12pt;
+        }
+
+        .vat {
+          vertical-align: top;
+        }
+
+      </style>
+      <body>
+        <!-- stop head -->
+        <div class="t9">

--- a/templates/models4printAuto/certif-certificatVierge.html.twig
+++ b/templates/models4printAuto/certif-certificatVierge.html.twig
@@ -1,0 +1,35 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : certificat vierge
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+{% set tag = page.courrier %}
+
+
+
+<p style="text-align:right">{{ tag.UtilisateurActif_villeAdressePro }}, le {{ "now"|date("d/m/Y") }}</p> <br><br><br>
+<br><br><br>
+
+<p>Je soussigné</p>

--- a/templates/models4printAuto/courrier-courrierVierge.html.twig
+++ b/templates/models4printAuto/courrier-courrierVierge.html.twig
@@ -1,0 +1,34 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : courrier vierge
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+{% set tag = page.courrier %}
+
+
+
+<p style="text-align:right">{{ tag.UtilisateurActif_villeAdressePro }}, le {{ "now"|date("d/m/Y") }}</p>
+<br><br><br>
+<p>Cher Confrère, </p>

--- a/templates/models4printAuto/courrier-ttEnCours.html.twig
+++ b/templates/models4printAuto/courrier-ttEnCours.html.twig
@@ -1,0 +1,55 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : courrier vierge
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+{% import "macroLap.html.twig" as lap %}
+{% set tag = page.courrier %}
+
+
+<p style="text-align:right">{{ tag.UtilisateurActif_villeAdressePro }}, le {{ "now"|date("d/m/Y") }}</p>
+<br>
+<h2>Traitement en cours de {{ tag.identiteCompleteTitreLongDdn }}</h2>
+
+{% if tag.tt.TTChroniques is not empty %}
+<h3><u>Traitements chroniques</u></h3>
+
+<p>Traitements en cours ou présumé en cours de par la nature chronique :</p>
+<ol>
+{% for l in tag.tt.TTChroniques %}
+  {{ lap.lignePres(l, false) }}
+{% endfor %}
+</ol>
+
+{% endif %}
+
+{% if tag.tt.TTPonctuels is not empty %}
+<h3><u>Traitements ponctuels</u></h3>
+
+<ol>
+{% for l in tag.tt.TTPonctuels %}
+  {{ lap.lignePres(l, true) }}
+{% endfor %}
+</ol>
+{% endif %}

--- a/templates/models4printAuto/csBase.html.twig
+++ b/templates/models4printAuto/csBase.html.twig
@@ -1,0 +1,37 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : compte-rendu de consultation
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ # @contrib fr33z00 <https://github.com/fr33z00>
+ #}
+
+{% set tag = page.courrier %}
+
+<p style="text-align : right;">{{ tag.utilisateuractif_villeadressepro }}, le {{ tag.date|date("d/m/Y") }}</p>
+
+<h2 style="text-align : center">{{ tag.identiteCompleteTitreLongDdn }}</h2>
+
+<h3>Consultation du jour</h3>
+
+{{ tag.examenDuJour|nl2br }}

--- a/templates/models4printAuto/csImportee.html.twig
+++ b/templates/models4printAuto/csImportee.html.twig
@@ -1,0 +1,32 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : compte-rendu pour examen importé depuis un autre EHR    
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+{% set tag = page.courrier %}
+
+
+
+{{ tag.252|nl2br }}

--- a/templates/models4printAuto/facture.html.twig
+++ b/templates/models4printAuto/facture.html.twig
@@ -1,0 +1,42 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2019
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : facture
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+ {% set tag = page.courrier %}
+
+<p style="text-align : right;">{{ tag.UtilisateurActif_villeAdressePro }}, le {{ tag.date|date("d/m/Y") }}</p>
+
+ <h2 style="text-align : center">{{ tag.identiteCompleteTitreLongDdn }}</h2>
+ <br><br><br>
+ <p>Je soussigné {{ tag.UtilisateurActif_identiteUsuelleTitre	}} certifie avoir reçu ce jour de {{ tag.identiteCompleteTitreLongDdn }} la somme de {{ tag.regleFacture }}€ en règlement des honoraires de consultation.<br><br>
+
+ </p>
+
+ <p>Certificat remis en mains propre pour faire valoir ce que de droit.</p>
+
+ <br><br><br><br><br><br>
+
+ <p style="text-align:right">{{ tag.UtilisateurActif_identiteUsuelleTitre	}}</p>

--- a/templates/models4printAuto/ordonnanceALD.html.twig
+++ b/templates/models4printAuto/ordonnanceALD.html.twig
@@ -1,0 +1,165 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : ordonnance ALD
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+{% set tag = page.courrier %}
+
+
+{% set ms = page.courrier.medoc.standard %}
+{% set ma = page.courrier.medoc.ald %}
+
+
+    <html>
+        <head>
+            <style>
+                @page {
+                    margin: 140pt 50pt 100pt;
+                    font-family: Helvetica;
+                }
+
+                #header {
+                    position: fixed;
+                    left: 0;
+                    top: -110pt;
+                    right: 0;
+                    height: 110pt;
+                    margin-bottom: 30pt;
+
+                }
+                #footer {
+                    position: fixed;
+                    left: 0;
+                    bottom: -110pt;
+                    right: 0;
+                    height: 100pt;
+                    font-size: 8pt;
+                    padding-top: 10pt;
+                    border-top: 1pt solid #777;
+                }
+
+                #footer p {
+                    display: inline-block;
+                    width: 30%;
+                    text-align: center;
+                    vertical-align: top;
+                }
+
+                .gras {
+                    font-weight: bold;
+                }
+
+                .blocsepa {
+                    width: 100%;
+                    border: 1px solid #000;
+                    text-align: center;
+                }
+
+                .centrer {
+                  text-align : center;
+                }
+                .t6 {
+                  font-size : 6pt;
+                }
+                .t8 {
+                  font-size : 8pt;
+                }
+                .t9 {
+                  font-size : 9pt;
+                }
+                .t10 {
+                  font-size : 10pt;
+                }
+                .t12 {
+                  font-size : 12pt;
+                }
+
+            </style>
+            <body>
+
+                {% set tag = page.courrier %}
+
+                <div id="header">
+                    <div class="centrer t8" style="display : inline-block; width : 45%;vertical-align : top; border : 1px solid #000;height : 110pt">
+                        <span class="gras t10">{{ tag.AuteurInitial_identiteUsuelleTitre	}}</span><br>
+                        Conventionnée secteur 1<br>
+                        N°ADELI : {{ tag.AuteurInitial_adeli }} <br>
+                        RPPS : {{ tag.AuteurInitial_rpps }} <br>
+                        {{ tag.AuteurInitial_etablissementAdressePro }}<br>
+                        {{ tag.AuteurInitial_adresseProLigne1 }}<br>
+                        {{ tag.AuteurInitial_adresseProLigne2 }}<br>
+                        Consultations sur RDV : {{ tag.AuteurInitial_telPro }}<br>
+                        En cas d’urgence, composez le 15
+                    </div>
+
+                    <div class="centrer t10" style=" display : inline-block; float : right; width : 45%; vertical-align : top; border : 1px solid #000; height : 110pt">
+                        <br><br><br>
+                        <span class="gras t10">{{ tag.identiteCompleteTitreCourt }}
+                        </span><br>{{ tag.birthdate }} - {{ tag.age }}
+                    </div>
+                </div>
+
+                <!-- footer standard -->
+                <div id="footer">
+                    <p>RPPS<br><img src="data:image/png;base64,{{ tag.rppsbarcode }}" style="width : 130px; height : 40px"><figcaption>{{ tag.AuteurInitial_rpps  }}</figcaption></p>
+                    <p>ADELI<br><img src="data:image/png;base64,{{ tag.rppsbarcode }}" style="width : 130px; height : 40px"><figcaption>{{ tag.AuteurInitial_adeli  }}</figcaption></p>
+                    <p><br>Membre d’une AGA, règlement par chèque accepté.</p>
+                </div>
+                <!-- stop head -->
+                <div class="t10">
+                    <p style="text-align : right;">{{ tag.AuteurInitial_villeAdressePro }}, le
+                        {{ tag.date|date("d/m/Y") }}</p>
+
+                    <div>
+                        <div class="centrer" style="width: 100%; border: 1px solid #000;">
+                            <strong>Prescriptions relatives au traitement de l'affection de longue durée reconnue (liste ou hors liste)</strong><br>
+                            (AFFECTION EXONERANTE)
+                        </div>
+                        {% if tag.ordoImpressionNbLignes != 'n' %}
+                        <p class="t8" style="text-align : right;">{{ ma|length }} ligne{% if ma|length > 1 %}s{% endif %} de prescriptions</p>
+                        {% endif %}
+
+                        {% for v in ma %}
+                            <p class="t8" style="margin-bottom: 8pt;">{{ v|nl2br }}</p>
+                        {% endfor %}
+
+                    </div>
+
+                    <div class="centrer" style="width: 100%; border: 1px solid #000;">
+                        <strong>Prescriptions SANS RAPPORTS avec l'affection de longue durée</strong><br>
+                        (MALADIES INTERCURRENTES)
+                    </div>
+                    {% if tag.ordoImpressionNbLignes != 'n' %}
+                    <p class="t8" style="text-align : right;">{{ ms|length }} ligne{% if ms|length > 1 %}s{% endif %} de prescriptions</p>
+                    {% endif %}
+
+                    {% for v in ms %}
+                        <p class="t8" style="margin-bottom: 8pt;">{{ v|nl2br }}</p>
+                    {% endfor %}
+
+                </div>
+                <!-- stop body -->
+            </body>
+        </html>

--- a/templates/models4printAuto/ordonnanceAnonyme.html.twig
+++ b/templates/models4printAuto/ordonnanceAnonyme.html.twig
@@ -1,0 +1,122 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : ordonnance à auteur anonyme pour LAP
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+    <html>
+        <head>
+            <style>
+                @page {
+                    margin: 170pt 50pt 40pt 50pt;
+                    font-family: Helvetica;
+                }
+                #header {
+                    position: fixed;
+                    left: 0;
+                    top: -150pt;
+                    right: 0;
+                    height: 140pt;
+                    margin-bottom: 40pt;
+                    border-bottom: 1pt solid #777;
+                }
+
+                h2 {
+                  margin-top : 4pt;
+                }
+
+                h3 {
+                  margin : 12pt 0 5pt 0;
+                  padding : 0;
+                }
+
+                h4 {
+                  margin : 10pt 0 3pt 0;
+                  padding : 0;
+                }
+
+                ul {
+                  margin : 0 0 0 10pt;
+                  padding : 0;
+                }
+
+                .gras {
+                    font-weight: bold;
+                }
+                .centrer {
+                  text-align : center;
+                }
+                .t6 {
+                  font-size : 6pt;
+                }
+                .t8 {
+                  font-size : 8pt;
+                }
+                .t9 {
+                  font-size : 9pt;
+                }
+                .t10 {
+                  font-size : 10pt;
+                }
+                .t12 {
+                  font-size : 12pt;
+                }
+
+            </style>
+            <body>
+
+                <div id="header">
+                  <div class="t8" style="display : inline-block; width : 65%;vertical-align : bottom;">
+
+                  </div>
+
+                  <div class="t8" style=" display : inline-block; width : 35%; vertical-align : bottom; text-align : right;padding-top : 88pt;">
+
+                  </div>
+                </div>
+
+                <!-- stop head -->
+                <div class="t9">
+
+                {% set tag = page.courrier %}
+                {% set ms = page.courrier.medoc.standard %}
+                {% set ma = page.courrier.medoc.ald %}
+
+
+                <p style="text-align : right;">Le {{ tag.date|date("d/m/Y") }}</p>
+
+                <h2 style="text-align : center; margin-bottom : 30pt;">{{ tag.identiteCompleteTitreLongDdn }} - {{ tag.age }}</h2>
+
+                {% if tag.ordoImpressionNbLignes != 'n' %}
+                <p style="text-align : right;">{{ ms|length }} ligne{% if ms|length > 1 %}s{% endif %} de prescriptions</p>
+                {% endif %}
+
+                {% for v in ms %}
+                <p style="margin-bottom: 12pt;">{{ v|nl2br }}</p>
+                {% endfor %}
+
+
+                <!-- stop body -->
+            </body>
+        </html>

--- a/templates/models4printAuto/ordonnanceAnonymeALD.html.twig
+++ b/templates/models4printAuto/ordonnanceAnonymeALD.html.twig
@@ -1,0 +1,153 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : ordonnance ALD
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+{% set tag = page.courrier %}
+
+
+{% set ms = page.courrier.medoc.standard %}
+{% set ma = page.courrier.medoc.ald %}
+
+
+    <html>
+        <head>
+            <style>
+                @page {
+                    margin: 140pt 50pt 100pt;
+                    font-family: Helvetica;
+                }
+
+                #header {
+                    position: fixed;
+                    left: 0;
+                    top: -110pt;
+                    right: 0;
+                    height: 110pt;
+                    margin-bottom: 30pt;
+
+                }
+                #footer {
+                    position: fixed;
+                    left: 0;
+                    bottom: -110pt;
+                    right: 0;
+                    height: 100pt;
+                    font-size: 8pt;
+                    padding-top: 10pt;
+                    border-top: 1pt solid #777;
+                }
+
+                #footer p {
+                    display: inline-block;
+                    width: 30%;
+                    text-align: center;
+                    vertical-align: top;
+                }
+
+                .gras {
+                    font-weight: bold;
+                }
+
+                .blocsepa {
+                    width: 100%;
+                    border: 1px solid #000;
+                    text-align: center;
+                }
+
+                .centrer {
+                  text-align : center;
+                }
+                .t6 {
+                  font-size : 6pt;
+                }
+                .t8 {
+                  font-size : 8pt;
+                }
+                .t9 {
+                  font-size : 9pt;
+                }
+                .t10 {
+                  font-size : 10pt;
+                }
+                .t12 {
+                  font-size : 12pt;
+                }
+
+            </style>
+            <body>
+
+                <div id="header">
+                    <div class="centrer t8" style="display : inline-block; width : 45%;vertical-align : top; border : 1px solid #000;height : 110pt">
+
+                    </div>
+
+                    <div class="centrer t10" style=" display : inline-block; float : right; width : 45%; vertical-align : top; border : 1px solid #000; height : 110pt">
+                        <br><br><br>
+                        <span class="gras t10">{{ tag.identiteCompleteTitreCourt }}
+                        </span><br>{{ tag.birthdate }} - {{ tag.age }}
+                    </div>
+                </div>
+
+                <!-- footer standard -->
+                <div id="footer">
+
+                </div>
+                <!-- stop head -->
+                <div class="t10">
+                    <p style="text-align : right;">Le
+                        {{ tag.date|date("d/m/Y") }}</p>
+
+                    <div>
+                        <div class="centrer" style="width: 100%; border: 1px solid #000;">
+                            <strong>Prescriptions relatives au traitement de l'affection de longue durée reconnue (liste ou hors liste)</strong><br>
+                            (AFFECTION EXONERANTE)
+                        </div>
+                        {% if tag.ordoImpressionNbLignes != 'n' %}
+                        <p class="t8" style="text-align : right;">{{ ma|length }} ligne{% if ma|length > 1 %}s{% endif %} de prescriptions</p>
+                        {% endif %}
+
+                        {% for v in ma %}
+                            <p class="t8" style="margin-bottom: 8pt;">{{ v|nl2br }}</p>
+                        {% endfor %}
+
+                    </div>
+
+                    <div class="centrer" style="width: 100%; border: 1px solid #000;">
+                        <strong>Prescriptions SANS RAPPORTS avec l'affection de longue durée</strong><br>
+                        (MALADIES INTERCURRENTES)
+                    </div>
+                    {% if tag.ordoImpressionNbLignes != 'n' %}
+                    <p class="t8" style="text-align : right;">{{ ms|length }} ligne{% if ms|length > 1 %}s{% endif %} de prescriptions</p>
+                    {% endif %}
+
+                    {% for v in ms %}
+                        <p class="t8" style="margin-bottom: 8pt;">{{ v|nl2br }}</p>
+                    {% endfor %}
+
+                </div>
+                <!-- stop body -->
+            </body>
+        </html>

--- a/templates/models4printAuto/ordonnanceBody.html.twig
+++ b/templates/models4printAuto/ordonnanceBody.html.twig
@@ -1,0 +1,49 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : corps d'une ordonnance non ALD
+ # (header et footer sont indiqués en fichier de config)
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+{% set tag = page.courrier %}
+{% set ms = page.courrier.medoc.standard %}
+{% set ma = page.courrier.medoc.ald %}
+
+
+<p style="text-align : right;">{{ tag. AuteurInitial_villeAdressePro}}, le {{ tag.date|date("d/m/Y") }}</p>
+
+<h2 style="text-align : center; margin-bottom : 30pt;">{{ tag.identiteCompleteTitreLongDdn }} - {{ tag.age }}</h2>
+
+{% if tag.ordoImpressionNbLignes != 'n' %}
+<p style="text-align : right;">{{ ms|length }} ligne{% if ms|length > 1 %}s{% endif %} de prescriptions</p>
+{% endif %}
+
+{% for v in ms %}
+<p style="margin-bottom: 12pt;">{{ v|nl2br }}</p>
+{% endfor %}
+
+
+<br><br><br><br>
+
+<p style="text-align:right">{{ tag.AuteurInitial_identiteUsuelleTitre	}}</p>

--- a/templates/models4printAuto/rapportImagesDicom.html.twig
+++ b/templates/models4printAuto/rapportImagesDicom.html.twig
@@ -1,0 +1,48 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2017
+ # Bertrand Boutillier <b.boutillier@gmail.com>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > models4print : modèle pour création PDF images dicom
+ #
+ # @author Bertrand Boutillier <b.boutillier@gmail.com>
+ #}
+
+{% set tag = page.courrier %}
+
+
+<p style="text-align : right;">{{ tag.UtilisateurActif_villeAdressePro }}, le
+    {{ tag.date|date("d/m/Y") }}</p>
+
+<h2 style="text-align : center">{{ tag.identiteCompleteTitreLongDdn }}</h2>
+
+{{ tag.images|length }} image{% if tag.images|length > 1 %}s{% endif %} - {{ (tag.images|length / 6)|round(0, 'ceil') }} page{% if tag.images|length > 6 %}s{% endif %}
+
+<table>
+    <tr>
+        {% for img in tag.images %}
+            <td style="width : 50%"><img src="{{ img }}" style="width : 8.5cm" /></td>
+            {% if loop.index is even %}
+            </tr>
+            <tr>
+            {% endif %}
+        {% endfor %}
+    </tr>
+</table>

--- a/templates/models4printAuto/styles.html.twig
+++ b/templates/models4printAuto/styles.html.twig
@@ -1,0 +1,74 @@
+<style>
+
+  .gras {
+    font-weight: bold;
+  }
+  .centrer {
+    text-align: center;
+  }
+  .t6 {
+    font-size: 6pt;
+  }
+  .t8 {
+    font-size: 8pt;
+  }
+  .t9 {
+    font-size: 9pt;
+  }
+  .t10 {
+    font-size: 10pt;
+  }
+  .t12 {
+    font-size: 12pt;
+  }
+
+  h2 {
+    margin-top: 4pt;
+  }
+
+  h3 {
+    margin: 12pt 0 5pt;
+    padding: 0;
+  }
+
+  h4 {
+    margin: 10pt 0 3pt;
+    padding: 0;
+  }
+
+  ul {
+    margin: 0 0 0 10pt;
+    padding: 0;
+  }
+
+  .vat {
+    vertical-align: top;
+  }
+
+  .cbox {
+    font-family: DejaVu Sans, sans-serif;
+    font-size: 10pt;
+  }
+
+  th {
+    background: #000;
+    color: #FFF;
+    text-align: center;
+    font-size: 10pt;
+  }
+
+  .tabPatiente td {
+    vertical-align: top;
+    margin: 0;
+    padding: 0;
+    text-align: left;
+  }
+
+  .bordurelat {
+    border-left: 1pt solid #000;
+    border-right: 1pt solid #000;
+
+  }
+
+
+</style>


### PR DESCRIPTION
Permet de récupérer dans le tag `page.courrier` les donnée de l'utilisateur actif et de l'auteur initial (récupérer via les donnée le l'objet lui même) dans les documents de type courrier. Pour les nouveau courrier l'auteur initial est l'utilisateur actif et pour les modifications de courrier existant l'auteur initial est récupérer via le fromID de la donnée elle même.

Ajoute aussi une copie des templates de base dans `templates/models4PrintAuto` afin de pouvoir choisir des templates ou les donnée des entêtes et du footer son récupéré directement depuis les données pro du praticien (sans pour autant modifier les templates de bases).

C'est très utilise dans le cas d'un cabinet avec de nombreux praticiens et/ou quant ils sont amenés à changer ou être remplacés régulièrement.