### PR TITLE
fix(msObjet::getObjetChildsByNames) : valeurs entre  quote dans sqlQuery

### DIFF
--- a/class/msObjet.php
+++ b/class/msObjet.php
@@ -219,7 +219,7 @@ public function getToID()
           return msSQL::sql2tabKey("select o.*, t.name
           from objets_data as o
           left join data_types as t on o.typeID=t.id
-          where o.typeID in (".implode(', ', $name2typeID).") and o.instance='".$this->_ID."' and o.outdated='' and o.deleted='' ", $by);
+          where o.typeID in ('".implode("', '", $name2typeID)."') and o.instance='".$this->_ID."' and o.outdated='' and o.deleted='' ", $by);
         }
     }
 

--- a/class/msObjet.php
+++ b/class/msObjet.php
@@ -219,7 +219,7 @@ public function getToID()
           return msSQL::sql2tabKey("select o.*, t.name
           from objets_data as o
           left join data_types as t on o.typeID=t.id
-          where o.typeID in ('".implode(', ', $name2typeID)."') and o.instance='".$this->_ID."' and o.outdated='' and o.deleted='' ", $by);
+          where o.typeID in (".implode(', ', $name2typeID).") and o.instance='".$this->_ID."' and o.outdated='' and o.deleted='' ", $by);
         }
     }
 


### PR DESCRIPTION
Dans la requette sql de la fonction pour le `where o.typeID in` les
valeur passé entre `()` pour le `in` sont entres `'` ce qui empèche la
requette re trourner un résultat pour tout les typeID fournis.