### PR TITLE
fix(form courriel): inclus de js des fromulaire dans ceux des courriel

### DIFF
--- a/controlers/patient/actions/inc-ajax-extractMailForm.php
+++ b/controlers/patient/actions/inc-ajax-extractMailForm.php
@@ -115,6 +115,7 @@ $form->setFormIDbyName($p['page']['formIN']=$_POST['formIN']);
 if(isset($preValues)) $form->setPrevalues($preValues);
 $form->setTypeForNameInForm('byName');
 $p['page']['form']=$form->getForm();
+$p['page']['formJavascript']=$form->getFormJavascript();
 $form->addSubmitToForm($p['page']['form'], 'btn-warning btn-lg btn-block', $submitLabel);
 
 $p['page']['form']['addHidden']=array(

--- a/templates/base/patient/mailForm.html.twig
+++ b/templates/base/patient/mailForm.html.twig
@@ -111,4 +111,11 @@
     {% else %}
       {{ f.formbuilder(page.form , page.formIN ) }}
     {% endif %}
+
+    {% if page.formJavascript is not empty %}
+      <script>
+       {{ page.formJavascript }}
+      </script>
+    {% endif %}
+
 </div>


### PR DESCRIPTION
Juste un oublie de l'inclusion du code js des formulaire dans les formulaires d'envoi de courriel.