### PR TITLE
Fix: MySQL 8 mots clés réservés ON DUPLICATE KEY

### DIFF
--- a/class/msSQL.php
+++ b/class/msSQL.php
@@ -208,7 +208,7 @@ class msSQL
           }
           $cols[]=$key;
           $valeurs[]='\''.$val.'\'';
-          $dupli[]=$key.'=VALUES('.$key.')';
+		  $dupli[]='`'.$key.'`=VALUES(`'.$key.'`)';
       }
       if (self::sqlQuery("insert into `".self::cleanVar($table)."` (`".implode('`, `', $cols)."`) values (".implode(',', $valeurs).") ON DUPLICATE KEY UPDATE ".implode(', ', $dupli)." ;")) {
           return $mysqli->insert_id;


### PR DESCRIPTION
Bloquant lors de la création d'un premier utilisateur sous MySQL 8.