### PR TITLE
fix: mariadb not started on WSL

### DIFF
--- a/installer/debian-bash-installer.sh
+++ b/installer/debian-bash-installer.sh
@@ -147,6 +147,7 @@ mariadbInstall() {
     read -p "Choix du nom de l'admin de mysql : " mysqladmin
     read -s -r -p "Choix du mot de passe admin de mysql : " mysqlpass 
     echo
+    service mysql start
     mysql <<EOF
     SET PASSWORD FOR 'root'@'localhost' = PASSWORD("${mysqlrootpass}");
     DELETE FROM mysql.user WHERE User='';


### PR DESCRIPTION
Fixe un bug sur Windows subsytem for Linux qui ne lance pas mariadb à la suite de son installation