### PR TITLE
fix: make dir persistent

### DIFF
--- a/tools/vagrant/main.yml
+++ b/tools/vagrant/main.yml
@@ -40,15 +40,23 @@
         group: root
         mode: 0644
 
+    - name: sync sources with working directory
+      copy: 
+        src: /vagrant/
+        dest: /opt/ehr 
+        remote_src: yes 
+        directory_mode: yes
+      when: stage == "testing"
+
     - name: Creating MEDSHAKEEHRPATH file
       copy:
-        dest: /vagrant/public_html/MEDSHAKEEHRPATH
+        dest: /opt/ehr/public_html/MEDSHAKEEHRPATH
         content: |
-          /vagrant
+          /opt/ehr
         
     - name: Add good permissions and ownership to medshakeehr folder
       ansible.builtin.file:
-        path: /vagrant
+        path: /opt/ehr
         state: directory
         recurse: yes
         owner: www-data
@@ -58,17 +66,12 @@
     - name: Composer upgrade on /ehr
       composer:
         command: upgrade
-        working_dir: /vagrant
+        working_dir: /opt/ehr
     
     - name: Composer upgrade on /ehr/public_html
       composer:
         command: upgrade
-        working_dir: /vagrant/public_html
-
-    - name: Print return information from the previous task
-      ansible.builtin.debug:
-        var: result
-        verbosity: 3
+        working_dir: /opt/ehr/public_html
 
     - name: Setup php.ini configuration.
       template:
@@ -218,7 +221,7 @@
     
     - name:  check if config.yml exist
       stat:
-        path: /vagrant/config/config.yml
+        path: /opt/ehr/config/config.yml
       register: ymlconfig 
       
     - name: Run msehr-cli

--- a/tools/vagrant/secrets-sample.yml
+++ b/tools/vagrant/secrets-sample.yml
@@ -16,6 +16,7 @@ maxInputVars: max_input_vars = 10000
 errorReporting: error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 displayErrors: Off
 displayStartupErrors: Off
+stage: "testing"
 msehrPackages:
     - apache2
     - composer

--- a/tools/vagrant/templates/msehr.vhost.conf.j2
+++ b/tools/vagrant/templates/msehr.vhost.conf.j2
@@ -8,12 +8,12 @@
 <VirtualHost *:443>
 	ServerName {{ domain }}
 	ServerAlias msehr ehr medshakeehr MedShakeEHR 
-	DocumentRoot /vagrant/public_html
+	DocumentRoot /opt/ehr/public_html
 	RewriteEngine On
 	SSLEngine On
     SSLCertificateFile /etc/ssl/{{ domain }}/{{ domain }}.pem
     SSLCertificateKeyFile /etc/ssl/{{ domain }}/{{ domain }}.key
-	<Directory /vagrant/public_html>
+	<Directory /opt/ehr/public_html>
 		Options FollowSymLinks
 		AllowOverride all
 		Require all granted

--- a/tools/vagrant/templates/msehrCli.sh.j2
+++ b/tools/vagrant/templates/msehrCli.sh.j2
@@ -4,5 +4,5 @@ msehrDbName={{ sqlDbName }}
 mysqlUser={{ sqlUserAccount }}
 mysqlUserPswd={{ sqlUserPassword }}
 msehrDom={{ domain }}
-export MEDSHAKEEHRPATH=/vagrant
-su www-data -s/bin/bash -c  "php /vagrant/public_html/install.php -N -s localhost -d $msehrDbName -u $mysqlUser -p $mysqlUserPswd -r https -D $msehrDom"
+export MEDSHAKEEHRPATH=/opt/ehr
+su www-data -s/bin/bash -c  "php /opt/ehr/public_html/install.php -N -s localhost -d $msehrDbName -u $mysqlUser -p $mysqlUserPswd -r https -D $msehrDom"


### PR DESCRIPTION
permet d'avoir une installation non influencée par la commande `vagrant reload`, tout en pouvant copier via `vagrant provision` et la variable stage = testing,  les modifications du répertoire mappé sur /vagrant