### PR TITLE
Feat : Nouveau patient depuis un fichier de la dropbox

### DIFF
--- a/controlers/people/peopleNew.php
+++ b/controlers/people/peopleNew.php
@@ -76,4 +76,16 @@ if($template != "forbidden") {
   $formpatient->addHiddenInput($p['page']['form'],['peopleType'=>$p['page']['porp']]);
   $p['page']['formJavascript'][$p['page']['formIN']]=$formpatient->getFormJavascript();
   $formpatient->addSubmitToForm($p['page']['form'], 'btn-primary btn-block');
+
+  // Champs récupérer si formulaire de création d'un nouveau patient est appelé depuis la boîte de dépot avec le boutton "Nouvau patient avec les éléments du fichier"
+  if (!empty($_POST['createFromDropbox']) && $_POST['createFromDropbox'] == 1) {
+    $p['page']['createFromDropbox'] = 1;
+    $p['page']['form']['addHidden']['createFromDropbox'] = 1;
+    $p['page']['form']['addHidden']['dropboxFilename'] = $_POST['dropboxFilename'];
+    $p['page']['form']['addHidden']['dropboxBox'] = $_POST['dropboxBox'];
+    $p['page']['form']['addHidden']['dropboxDocTitle'] = $_POST['dropboxDocTitle'];
+  } else {
+    $p['page']['createFromDropbox'] = 0;
+  }
+
 }

--- a/templates/base/dropbox/dropboxViewDoc.html.twig
+++ b/templates/base/dropbox/dropboxViewDoc.html.twig
@@ -120,7 +120,8 @@
 
     <div class="form-group col-9 offset-3">
       <label for="titreOptionnel">Titre (optionnel)</label>
-      <input type="text" id="titreOptionnel" name="titre" class="form-control" placeholder="titre du document" value="{{ page.boxParams.filesDefaultTitle }}">
+      {# le js dans onchange="" permet de récupérer le titre du document avec la dans le champ hidden "dropboxDocTitle" du formulaire "CreerPatient" #}
+      <input type="text" id="titreOptionnel" name="titre" class="form-control" placeholder="titre du document" value="{{ page.boxParams.filesDefaultTitle }}" onchange="document.getElementById('creerPatient_doctitre').value = this.value;">
     </div>
   </div>
   <div class="row mb-4">
@@ -129,6 +130,26 @@
       </button>
     </div>
   </div>
+</form>
+
+<form id="CreerPatient" action="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/patient/create/" method="post">
+
+    <input type="hidden" name="createFromDropbox" value="1"/>
+    <input type="hidden" name="dropboxFilename" value="{{ page.fileData.filename }}"/>
+    <input type="hidden" name="dropboxBox" value="{{ page.boxParams.id }}"/>
+    <input id="creerPatient_doctitre" name="dropboxDocTitle" type="hidden" value="{{ page.boxParams.filesDefaultTitle }}">
+
+    <input name="lastname" type="hidden" value="{{ page.dataFromFilename.lastname|e|upper }}">
+    <input name="birthname" type="hidden" value="{{ page.dataFromFilename.birthname|e|upper }}">
+    <input name="firstname" type="hidden" value="{{ page.dataFromFilename.firstname|e|capitalize }}">
+    <input name="birthdate" type="hidden" value="{{ page.dataFromFilename.birthdate|e|capitalize }}">
+    <input name="nss" type="hidden" value="{{ page.dataFromFilename.nss|e }}">
+
+    <div class="row mb-4">
+        <div class="col text-right">
+            <input class="btn btn-primary" type="submit" value="Nouveau patient avec les éléments du fichier" title="Crée un nouvau patient avec les information issue du fichier et classe en même temps le fichier dans son dossier">
+        </div>
+    </div>
 </form>
 
 <div class="card mb-3">

--- a/templates/base/people/peopleNew.html.twig
+++ b/templates/base/people/peopleNew.html.twig
@@ -128,6 +128,21 @@ Nouveau registre
 </div>
 {% endif %}
 
+{% if page.createFromDropbox == 1 %}
+<div class="row">
+	<div class="col-xl-8 col-12">
+        <div class="alert alert-info" role="alert">
+            <h4>Patient crée à partir des informations présentent dans le nom d'un fichier de la boîte de dépot :</h4>
+            <ul class="list-unstyled">
+                <li><strong>Boîte de dépot : </strong>{{ page.form.addHidden.dropboxBox }}</li>
+                <li><strong>Nom du fichier : </strong>{{ page.form.addHidden.dropboxFilename }}</li>
+                <li><strong>Titre du document : </strong>{{ page.form.addHidden.dropboxDocTitle }}</li>
+            </ul>
+            <p><u>Le fichier sera automatiquement ajouté au dossier du patient et suprimé de la boîte de dépot.</u></p>
+        </div>
+	</div>
+</div>
+{% endif %}
 
 <div class="row">
 	<div class="col-xl-8 col-12">


### PR DESCRIPTION
Version cible Medshake EHR : 7.1.1

Permet de créée un nouveau patient depuis la boite de dépôt en fonction des informations extraites du nom du fichier.

Sur la page de la boite de dépôt un bouton est ajouté sous celui qui
permet de classer un fichier. Au clique sur ce bouton, le formulaire de
création d'un nouveau patient s'ouvre et les informations extraites du nom
du fichier sont pré-remplis. La validation du formulaire classe
automatiquement le fichier de la boite de dépôt dans le dossier du
nouveau patient.