### PR TITLE
Fix le controleur peopleSearch pour la page /todays/

### DIFF
--- a/class/msModBaseSqlGenerate.php
+++ b/class/msModBaseSqlGenerate.php
@@ -140,7 +140,7 @@ class msModBaseSqlGenerate extends msSqlGenerate
     'formFormulaireNouveauGroupe'=>'baseNewGroupe',
     'droitDossierPeutVoirUniquementPatientsGroupes'=>'false',
     'droitDossierPeutVoirUniquementPraticiensGroupes'=>'false',
-    'designTopMenuSections'=>"- agenda\n- patients\n- praticiens\n- groupes\n- registres\n- compta\n- inbox\n- dropbox\n- transmissions\n- outils",
+    'designTopMenuSections'=>"- agenda\n- podt\n- patients\n- praticiens\n- groupes\n- registres\n- compta\n- inbox\n- dropbox\n- transmissions\n- outils",
     'optionGeActiverAgenda'=>'true',
     'optionGeActiverCompta'=>'true',
     'optionGeActiverInboxApicrypt'=>'true',

--- a/controlers/rechercher/peopleSearch.php
+++ b/controlers/rechercher/peopleSearch.php
@@ -50,7 +50,7 @@ $form = new msForm;
 if($p['page']['porp'] == 'pro') {
   $template="searchPeoplePatientsAndPros";
   $form->setFormIDbyName($p['config']['formFormulaireNouveauPraticien']);
-} elseif($p['page']['porp'] == 'patient') {
+} elseif($p['page']['porp'] == 'patient' || $p['page']['porp'] == 'today') {
   $template="searchPeoplePatientsAndPros";
   $form->setFormIDbyName($p['config']['formFormulaireNouveauPatient']);
 } elseif($p['page']['porp'] == 'groupe') {


### PR DESCRIPTION
Sur le nouveau controleur *peopleSearch* de la v7 le cas `$p['page']['prop']`
n'est pas pris en compte ce qui provoque un crash au chargement de la
page `/todays/`.

Ajoute aussi le menu `podt` à `designTopMenuSections` (il ne figure pas par défaut sur la v7 et donc n'est pas affiché dans le menus sauf si on l'ajoute manuellement).