### PR TITLE
Indelog feat tags

### DIFF
--- a/class/msPeopleSearch.php
+++ b/class/msPeopleSearch.php
@@ -38,6 +38,10 @@ class msPeopleSearch
   private $_restricDossiersGroupes = false;
   private $_restricDossiersPratGroupes = false;
   private $_restricGroupesEstMembre = false;
+  /**
+   * @var $_univTagsFilter	Liste des ids de tags sur les quels filter les résultat
+   */
+  private $_univTagsFilter = array();
 
 /**
  * Définir une restriction pour ne retourner que ses propres dossiers patients
@@ -134,6 +138,15 @@ class msPeopleSearch
   public function setLimitNumber($limitNumber) {
     if(!is_numeric($limitNumber)) throw new Exception('LimitNumber is not numeric');
     $this->_limitNumber=$limitNumber;
+  }
+
+/**
+ * Définir la liste des ids de tags sur les quels filter les résultat
+ * @param	array	$tagsFilter	Liste des ID de tags sur les quels filter
+ */
+  public function setUnviTagsFilter(array $tagsFilter) {
+    // @TODO /!\ CLEAN $tagsFilter !!!
+    $this->_univTagsFilter = $tagsFilter;
   }
 
 /**
@@ -302,6 +315,11 @@ class msPeopleSearch
 
         }
     }
+
+    // Ajout du filtre sur les tag universel
+    if (!empty($this->_univTagsFilter))
+      $sp['where'][] .= 'p.id IN (SELECT DISTINCT toID FROM univtags_join AS uj LEFT JOIN univtags_tag AS ut ON ut.id = uj.tagID WHERE tagID in ('.implode(',', $this->_univTagsFilter).') GROUP BY toID HAVING(COUNT(tagID)) = '.count($this->_univTagsFilter).') ';
+
     return $sp['where'];
 
   }

--- a/class/msUnivTags.php
+++ b/class/msUnivTags.php
@@ -664,7 +664,6 @@ Class msUnivTags {
 		$p['page']['univTags']['contexte'] = $contexte;
 		$p['page']['univTags']['typeName'] = self::getTypeNameById($typeID);
 		// Si le tagID est supérieur à 0 fetch le tag pour récupérer ses propriété
-		$p['page']['univTags']['tagListe'] = msUnivTags::getList($typeID);
 		if ($tagID > 0) {
 			$tag = new self;
 			$tagProp = $tag->fetch($tagID);
@@ -683,6 +682,7 @@ Class msUnivTags {
 	 *							corespondre à ce que produit la méthode
 	 *							la méthode `getList()`.
 	 * @return	string			HTML.
+	 */
 	public static function getTagsCircleHtml(array $list)
 	{
 		$ret = '';

--- a/class/msUnivTags.php
+++ b/class/msUnivTags.php
@@ -1,0 +1,725 @@
+<?php
+/*
+ * This file is part of MedShakeEHR.
+ * http://www.medshake.net
+ *
+ * Copyright (c) 2021     DEMAREST Maxime <maxime@indelog.fr>
+ *
+ * MedShakeEHR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * MedShakeEHR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author	DEMAREST Maxime <maxime@indelog.fr>
+ * @brief	Class pour gérer les tags universel.
+ * @details	Les tags universel permettent de de disposer d'une fonction
+ *			d'étiquetage commune à tout les élément de MedShakeEHR la plus
+ *			indépandante possible du fonctionnement des élément tagués
+ *			permétant de grouper facilement ces élément ainsi que de
+ *			filter des résultat de recherches sur ceux ci.
+ *			Chaque type d'élément pouvant être tagués est idenfifié à
+ *			l'aide de type de tags définit dans la table indiqué par la
+ *			constante de class `TABLE_TYPE`. Par example un type de tag
+ *			peut être définit pour corresondre aux patients alors qu'un
+ *			autre sera définit pour à un pro ou encore à un rendez vous de
+ *			l'agenda. Chaque type de tags peut être indépandament activé
+ *			ou désactivé. Chaque type de tag possède ses propres
+ *			droits indiqués par les champs suivant de la table des type de
+ *			tags :
+ *				`droitCreSup` =>	Pour déterminier si un utilisateur peut
+ *									créer, suprimer ou modifier un tag pour
+ *									un type doné.
+ *				`droitAjoRet` =>	Pour déterminer si un utilisateur peut
+ *									ajouter ou retirer un tag sur un élément.
+ *			Chaque droit indiqué doit correspondre a un élément de type "Droit"
+ *			dans les paramètre de configuration.
+ *			Les tags sont liées à un élément via la table décrite dans la
+ *			contante de class `TABLE_JOIN`. La liaison se fait entre l'id
+ *			du tag et l'id de l'objet. La diférentiation entre les
+ *			diférents type d'objet lié se fait à l'aide de l'id du type de
+ *			tag.
+ */
+
+Class msUnivTags {
+
+
+	/**
+	 * @const TABLE_TAGS Nom de la table pour le stockage des tags universel.
+	 */
+	const TABLE_TAGS = 'univtags_tag';
+	/**
+	 * @const TABLE_TYPE Nom de la table utilisé pour la déscription des
+	 *		  types de tags universel.
+	 */
+	const TABLE_TYPE = 'univtags_type';
+	/**
+	 * @const TABLE_JOIN Nom de la table utilisé pour stoquer la
+	 *		  corespondant d'un tag avec un élément.
+	 */
+	const TABLE_JOIN = 'univtags_join';
+
+	/**
+	 * @var $_id Indentifiant unique du tag.
+	 */
+	private $_id;
+
+	/**
+	 * @var $_typeID Id du type de tag.
+	 */
+	private $_typeID;
+
+	/**
+	 * @var $_typeName Nom du type de tag.
+	 */
+	private $_typeName;
+
+	/**
+	 * @var $_name Nom du tag.
+	 */
+	private $_name;
+
+	/**
+	 * @var $_description Description du tag.
+	 */
+	private $_description;
+
+	/**
+	 * @var $_color Couleur du tag au format hexadécimal (#FFFFFF).
+	 */
+	private $_color;
+
+	/**
+	 * @var $_droitCreSup Nom du droit dans la configuration Medshake pour
+	 *                    créer et suprimer les tags en fonction leurs type.
+	 */
+	private $_droitCreSup;
+
+	/**
+	 * @var $_droitAjoRet Nom du droit dans la configuration Medshake pour
+	 *                    ajouter et retier un tag sur un élément en fonction
+	 *                    de son type.
+	 */
+	private $_droitAjoRet;
+
+	/**
+	 * Céer un nouveau TAG en fonction des propriétés définies.
+	 * @return Array	Tableau des propriété du tag nouvellement créé.
+	 */
+	public function create() {
+		if (empty($this->_typeID)) throw new Exception(__METHOD__.' : $this->_typeID non définit');
+		if (empty($this->_name)) throw new Exception(__METHOD__.' : $this->_name non définit');
+		if (empty($this->_description)) throw new Exception(__METHOD__.' : $this->_description non définit');
+		if (empty($this->_color)) throw new Exception(__METHOD__.' : $this->_color non définit');
+
+		// Vérifie si aucun autre tag commporte le name avec ce typeID
+		// (le name doit être unique pour un typeID donnée)
+		$sql = 'SELECT `id` FROM '.self::TABLE_TAGS.' WHERE `name` = "'.$this->_name.'" AND `typeID` = "'.$this->_typeID.'"';
+		$resql = msSQL::sqlQuery($sql);
+		if (empty($resql)) throw new Exception(__METHOD__.' : erreur sql sur la vérification de l\'exisance du typeID');
+		else if ($resql->num_rows > 0) throw new Exception('Une étiquette portant déjà ce nom existe pour ce type.');
+
+		$data = array(
+			'typeID' => $this->_typeID,
+			'name' => $this->_name,
+			'description' => $this->_description,
+			'color' => $this->_color,
+		);
+		$res = msSQL::sqlInsert(self::TABLE_TAGS, $data);
+		if (! $res) throw new Exception(__METHOD__.' : échec insersion SQL');
+		return (int) $res;
+	}
+
+	/**
+	 * Met à jour un tags en fonction de ses propriété.
+	 * @return	Array	Nouvelle propriété du tag.
+	 */
+	public function update() {
+		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+
+		$data = msSQL::cleanArray(array(
+			'name' => $this->_name,
+			'description' => $this->_description,
+			'color' => $this->_color,
+		));
+
+		$setFields = array_map(function($k,$v) {return $k.' = "'.$v.'"';}, array_keys($data), $data);
+		$sql = 'UPDATE '.self::TABLE_TAGS.' SET '.implode(',', $setFields).' WHERE id = '.$this->_id;
+		$resql = msSQL::sqlQuery($sql);
+
+		if (empty($resql)) throw new Exception(__METHOD__.' : erreur sql update');
+		return $resql;
+	}
+
+	/**
+	 * Suprime le tag instancié.
+	 * @return	void
+	 */
+	public function delete() {
+		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+
+		// TODO remplacer ça par un delete cascade et une une clé étangère
+		// sur la table TABLE_JOIN ?  dabor supprimer les liaison ou est
+		// utilisé le tag dans TABLE_JOIN
+		$sql = 'DELETE FROM '.self::TABLE_JOIN.' WHERE tagID = '.$this->_id;
+		$resql = msSQL::sqlQuery($sql);
+		if (! $resql) throw new Exception(__METHOD__.' : erreur sql supression liaison tags');
+
+		$sql = 'DELETE FROM '.self::TABLE_TAGS.' WHERE id = '.$this->_id;
+		$resql = msSQL::sqlQuery($sql);
+		if (empty($resql)) throw new Exception(__METHOD__.' : erreur sql supression tags');
+		unset($this->_id);
+		return void;
+	}
+
+	/**
+	 * Récupére les propriétés d'un tag avec son ID.
+	 * @param	int		$id		ID du tag.
+	 * @return	Array			Tableau avec les propriétés du tag.
+	 */
+	public function fetch(int $id) {
+		$sql  = 'SELECT tag.id AS id, tag.name AS name, tag.description AS description, tag.color AS color, type.id AS typeID, type.name AS typeName, type.droitCreSup AS droitCreSup, type.droitAjoRet AS droitAjoRet';
+	    $sql .=	' FROM '.self::TABLE_TAGS.' AS tag LEFT JOIN '.self::TABLE_TYPE.' AS type ON type.id = tag.typeID';
+		$sql .= ' WHERE tag.id = '.$id;
+
+		$resql = msSQL::sqlUnique($sql);
+		if (empty($resql)) throw new Exception(__METHOD__.' : échec select sql');
+
+		$this->_id = $resql['id'];
+		$this->_name = $resql['name'];
+		$this->_description = $resql['description'];
+		$this->_color = $resql['color'];
+		$this->_typeID = $resql['typeID'];
+		$this->_typeName = $resql['typeName'];
+		$this->_droitCreSup = $resql['droitCreSup'];
+		$this->_droitAjoRet = $resql['droitAjoRet'];
+
+		return $resql;
+	}
+
+	/**
+	 * Défini le typeID du tag.
+	 * @param	int		$typeID		ID du type.
+	 * @return	int					Type ID défini.
+	 */
+	public function setTypeID(int $typeID) {
+		// test si le type existe
+		if (! self::checkTypeExist($typeID)) throw new Exception(__METHOD__.' : typeID='.$typeID.' inexistant');
+		$this->_typeID = $typeID;
+		return $this->_typeID;
+	}
+
+	/**
+	 * Défini le nom du tag.
+	 * @param	string		$name		Nom du tag.
+	 * @return	string					Le nom du tag défini.
+	 */
+	public function setName(string $name) {
+		if (empty($name)) throw new Exception(__METHOD__.' : $name ne doit pas être vide.');
+		$this->_name = trim(filter_var($name, FILTER_SANITIZE_STRING));
+		return $this->_name;
+	}
+
+	/**
+	 * Défini la déscription du tag.
+	 * @param	string		$description	Déscription du tag.
+	 * @return	string						La déscription du tag définit.
+	 */
+	public function setDescription(string $description) {
+		if (empty($description)) throw new Exception(__METHOD__.' : $description ne doit pas être vide.');
+		$this->_description = trim(filter_var($description, FILTER_SANITIZE_STRING));
+		return $this->_description;
+	}
+
+	/**
+	 * Défini la couleur du tag.
+	 * @param	string		$color		Couleur au format héxadécimal
+	 *									(#FFFFFF).
+     * @return	string					La couleur défini.
+	 */
+	public function setColor(string $color) {
+		if (filter_var($color, FILTER_VALIDATE_REGEXP, array('option'=>'/^#[0-9A-Fa-f]{6}$/')))
+			throw new Exception(__METHOD__.' : couleur='.$color.' n\'est pas dans le format de coleur attendus (/^#[0-9A-Fa-f]{6}$/)');
+		$this->_color = strtoupper($color);
+		return $this->_color;
+	}
+
+	/**
+	 * Retourne l'id d'un tag.
+	 * @return	int			ID du tag.
+	 */
+	public function getID() {
+		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+		return $this->_id;
+	}
+
+	/**
+	 * Retroune le typeID du tag.
+	 * @return	int			typID du tag.
+	 */
+	public function getTypeID() {
+		if (empty($this->_typeID)) throw new Exception(__METHOD__.' : $this->_typeID non définit');
+		return $this->_typeID;
+	}
+
+	/**
+	 * Retourne le nom du tag.
+	 * @return	string		name du tag.
+	 */
+	public function getName() {
+		if (empty($this->_name)) throw new Exception(__METHOD__.' : $this->_name non définit');
+		return $this->_name;
+	}
+
+	/**
+	 * Retroune la déscription du tag.
+	 * @return	string		description du tag.
+	 */
+	public function getDescription() {
+		if (empty($this->_description)) throw new Exception(__METHOD__.' : $this->_description non définit');
+		return $this->_description;
+	}
+
+	/**
+	 * Retoure la couleur en héxadécimal du TAG.
+	 * @return	string		couleur du tag en héxadécimal (#FFFFFF).
+	 */
+	public function getColor() {
+		if (empty($this->_color)) throw new Exception(__METHOD__.' : $this->_color non définit');
+		return $this->_color;
+	}
+
+	/**
+	 * Obtenir un liste de tags pour un type et un possesseur.
+	 * @param	int		$typeID		Id du type de tag pour le quel la liste.
+	 *								doit être récupéré.
+	 * @param	int		$toID		Id du possèseur du tag. Dépend du typeID.
+	 *								Si `0` la liste général pour le type est
+	 *								obtenu.
+	 * @param	bool	$onlyTo		Si vrais uniquement les tag du possésseur
+	 *								selon son type id sont retourné, autrement
+	 *								tout les tags pour le typeID sont retourné.
+	 * @return  array				Tableau ou chaque élément rerésente un tag
+	 *								et ses propriété. Les propriétés retourné
+	 *								pour chaque tag sont :
+	 *									'id' =>				Id du tag.
+	 *									'name' =>			Nom du tag.
+	 *									'description' =>	Description du tag.
+	 *									'color' =>			Couleur héxadécimal
+	 *														du tag.
+	 *									'typeID' =>			ID du type de tag.
+	 *									'typeName' =>		Nom du type de tag.
+	 *									'toID' =>			ID du propriétaire
+	 *														du tag relative à
+	 *														son type. Sera `null`
+	 *														si le paramètre $toID
+	 *														vaut `0`.
+	 *									'textcolor' =>		Couleur pour le texte
+	 *														du tag (noire ou blanc)
+	 *														dépandante de la couleur
+	 *														du tag.
+	 */
+	public static function getList(int $typeID, int $toID, bool $onlyTo  = false)
+	{
+		if (! self::checkTypeExist($typeID)) throw new Exception(__METHOD__.' : type non existant typeID='.$typeID);
+		$sql  = 'SELECT tag.id AS id, tag.name AS name, tag.description AS description, tag.color AS color, type.id AS typeID, type.name AS typeName, uj.toID AS toID';
+	    $sql .=	' FROM '.self::TABLE_TAGS.' AS tag LEFT JOIN '.self::TABLE_TYPE.' AS type ON type.id = tag.typeID';
+		$sql .= ' LEFT JOIN '.self::TABLE_JOIN.' AS uj ON uj.tagID = tag.id AND uj.toID = '.$toID;
+		$sql .= ' WHERE tag.typeID = '.$typeID;
+		if ($toID > 0 && $onlyTo) $sql .= ' AND uj.toID = '.$toID;
+		$sql .= ' ORDER BY tag.id ASC';
+		$res = msSQL::sql2tab($sql);
+		if (is_array($res) && count($res)>0) {
+			for ($i=0;$i<count($res);$i++) {
+				$res[$i]['textcolor'] = self::tagTextColor($res[$i]['color']);
+			}
+		}
+		return (is_null($res)) ? array() : $res;
+	}
+
+	/**
+	 * Tag un élément
+	 * @param	int		$toID		ID de l'élément sur le quel ajouter le tag.
+	 * @return	int					ID de l'élément sur le quel à été ajouté
+	 *								le tag.
+	 */
+	public function setTagTo(int $toID)
+	{
+		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+		$data = array(
+			'tagID' => $this->_id,
+			'toID' => $toID,
+		);
+		$res = msSQL::sqlInsert(self::TABLE_JOIN, $data);
+		if (empty($res)) throw new Exception(__METHOD__.' : Échec de l\'insertion SQL');
+		return $toID;
+	}
+
+	/**
+	 * Retirer le tag d'un élément
+	 * @param	int		$toID		ID de l'élément sur le quel retirer le tag.
+	 * @return	int					ID de l'élément sur le quel le tag à été
+	 *								retiré.
+	 */
+	public function removeTagTo(int $toID)
+	{
+		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+		$sql = 'DELETE FROM '.self::TABLE_JOIN.' WHERE `tagID` = '.$this->_id.' AND `toID` = '.$toID;
+		//// TODO check si erreur sur DELETE (sur v7.2 ne peut pas diférencier un retour null d'une erreur avec msSQL::sqlQuery())
+		msSQL::sqlQuery($sql);
+		return $toID;
+	}
+
+	/**
+	 * Retourne si l'utilisateur peut modifier ou suprimer le tag (dépendament
+	 * du paramètre de configuraton défini pour ce type de tag).
+	 * @return	bool	`true` si l'utilisateur peut modifier ou suprimer le tag
+	 *					`false` si non.
+	 */
+	public function checkDroitCreSup() {
+		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+		global $p;
+		return filter_var($p['config'][$this->_droitCreSup], FILTER_VALIDATE_BOOLEAN);
+	}
+
+	/**
+	 * Retourne si l'utilisateur peut ajouter ou retirer le tag (dépendament
+	 * du paramètre de configuraton défini pour ce type de tag) d'un élément.
+	 * @return	bool	`true` si l'utilisateur peut ajouter ou retirer le tag
+	 *					d'un élément, `false` si non.
+	 */
+	public function checkDroitAjoRet() {
+		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+		global $p;
+		return filter_var($p['config'][$this->_droitAjoRet], FILTER_VALIDATE_BOOLEAN);
+	}
+
+	/********************************
+	 * Méthodes de gestion des types
+	 *******************************/
+
+	/**
+	 * Obtenir la liste de type de tag.
+	 * @param	bool	$onlyActif		Si vrai, seulement la liste des type
+	 *									actif sera retourné.
+	 * @return	array					Tableau avec la liste de type de tag.
+	 *									Chaque élément du tableau comporte
+	 *									les propriété suivantes :
+	 *										'id'			=> ID du type.
+	 *										'description'	=> Description du type.
+	 *										'actif'			=> 1 si actif autrement 0
+	 *										'droitCreeSup'	=> nom du paramètre de
+	 *														   configuration déterminant
+	 *														   si un utilisateur peut
+	 *														   créer, suprimer, modifier
+	 *														   un tag de ce type.
+	 *										'roitAjoRet'	=> nom du paramètre de
+	 *														   configuration déterminant
+	 *														   si un utilisateur peut
+	 *														   ajouter ou retirer
+	 *														   un tag de ce type.
+	 */
+	public static function getTypeList($onlyActif = false)
+	{
+		$sql = 'SELECT `id`, `name`, `description`, `actif`, `droitCreSup`, `droitAjoRet` FROM '.self::TABLE_TYPE;
+		if ($onlyActif) $sql .= ' WHERE `actif`';
+		$res = msSQL::sql2tab($sql);
+		return $res;
+	}
+
+	/**
+	 * Obtenir le nom d'un type de tag avec son ID.
+	 * @param	int		$typeID		ID du type de tag.
+	 * @return	string				Nom du type de tag.
+	 */
+	public static function getTypeNameById(int $typeID) {
+		$sql = 'SELECT `name` FROM '.self::TABLE_TYPE.' WHERE `id` = '.$typeID;
+		$res = msSQL::sqlUniqueChamp($sql);
+		if (is_null($res)) throw new Exception(__METHOD__.' : aucun type avec id='.$typeID);
+		return $res;
+	}
+
+	/**
+	 * Obtenir l'id d'un type de tag avec son nom.
+	 * @param	string		$typeName	Nome du type.
+	 * @return	int						ID du type.
+	 */
+	public static function getTypeIdByName(string $typeName) {
+		$sql = 'SELECT `id` FROM '.self::TABLE_TYPE.' WHERE `name` = "'.msSQL::cleanVar($typeName).'"';
+		$res = msSQL::sqlUniqueChamp($sql);
+		if (is_null($res)) throw new Exception(__METHOD__.' : aucun type avec name="'.$typeName.'"');
+		return (int) $res;
+	}
+
+	/**
+	 * Vérifier si un type de tag existe.
+	 * @param	int		$typeID		ID du type.
+	 * @return	bool				`true` si le type existe autrement `false`.
+	 */
+	public static function checkTypeExist(int $typeID)
+	{
+		$sql = 'SELECT `id` FROM '.self::TABLE_TYPE.' WHERE `id` = '.$typeID;
+		$resql = msSQL::sqlQuery($sql);
+		if (empty($resql)) throw new Exception(__METHOD__.' : erreur sql');
+		return filter_var($resql->num_rows, FILTER_VALIDATE_BOOLEAN);
+	}
+
+	/**
+	 * Vérifier si type de tag existe.
+	 * @param	int		$typeID		ID du type.
+	 * @return	boot				`true` si existe autrement `false`.
+	 */
+	public static function getIfTypeIsActif(int $typeID)
+	{
+		if (!self::checkTypeExist($typeID)) throw new Exception(__METHOD__.' : Type de tag non existant');
+		$sql = 'SELECT `actif` FROM '.self::TABLE_TYPE.' WHERE `id` = '.$typeID;
+		$res = msSQL::sqlUniqueChamp($sql);
+		if (is_null($res)) throw new Exception(__METHOD__.' : erreur requette sql.');
+		return filter_var($res, FILTER_VALIDATE_BOOLEAN);
+	}
+
+	/**
+     * Activer ou désactiver un type de tag.
+	 * @param	int		$typeID		L'ID du type.
+	 * @param	bool	$actif		`true` pour activer le type, `false` pour
+	 *								le désactiver.
+	 * @return	bool				Le nouvel état du type.
+	 */
+	public static function setTypeActif(int $typeID, bool $actif)
+	{
+		if (!self::checkTypeExist($typeID)) throw new Exception(__METHOD__.' : Type de tag non existant');
+		$sql = 'UPDATE '.self::TABLE_TYPE.' SET `actif` = "'.((int)$actif).'" WHERE `id` = '.$typeID;
+		$resql = msSQL::sqlQuery($sql);
+		if (empty($resql)) throw new Exception(__METHOD__.' : erreur sql');
+		return $actif;
+	}
+
+	/**
+	 * Vérifie si l'utilisateur peut créer, modifier ou suprimer les tags du
+	 * type d'on l'ID est fourni en argument.
+	 * @param	int		$typeID		ID du type.
+	 * @return	bool				`true` si l'utilisatuer peut autrement `false`.
+	 */
+	public static function checkTypeDroitCreSup(int $typeID) {
+		if (!self::checkTypeExist($typeID)) throw new Exception(__METHOD__.' : Type de tag non existant');
+		global $p;
+		$sql = 'SELECT `droitCreSup` FROM '.self::TABLE_TYPE.' WHERE `id` = '.$typeID;
+		$res = msSQL::sqlUniqueChamp($sql);
+		if (is_null($res)) throw new Exception(__METHOD__.' : erreur requette sql.');
+		return filter_var($p['config'][$res], FILTER_VALIDATE_BOOLEAN);
+	}
+
+	/**
+	 * Vérifie si l'utilisateur peut ajouter ou retirer des tags du type d'on
+	 * l'ID est fourni en argument.
+	 * @param	int		$typeID		ID du type.
+	 * @return	bool				`true` si l'utilisatuer peut autrement `false`.
+	 */
+	public static function checkTypeDroitAjoRet(int $typeID) {
+		if (!self::checkTypeExist($typeID)) throw new Exception(__METHOD__.' : Type de tag non existant');
+		global $p;
+		$sql = 'SELECT `droitAjoRet` FROM '.self::TABLE_TYPE.' WHERE `id` = '.$typeID;
+		$res = msSQL::sqlUniqueChamp($sql);
+		if (is_null($res)) throw new Exception(__METHOD__.' : erreur requette sql.');
+		return filter_var($p['config'][$res], FILTER_VALIDATE_BOOLEAN);
+	}
+
+	/*************************************************************************
+	 * Méthode de rendu de contenus HTML
+	 ************************************************************************/
+
+	/**
+	 * Retoune le HTML d'une liste de tag selon un type, un propriétaire et un
+	 * contexte.
+	 * @param	int		$typeID		ID du type pour le quel la liste doit être
+	 *								obtenus.
+	 * @param	int		$toID		Propriétaire des tags de la list. `0` si
+	 *								la liste est obtenus dans un contexte général.
+	 * @param	string	$context	Contexte pour le quel générer la liste de
+	 *								tag. Peut être l'un des cas suivant :
+	 *									'config'	:
+	 *										Page de configuration global des
+	 *										tags universel. $toID doit valoir
+	 *										`0` dans se contexte. La liste de tag
+	 *										généré comporte le bouton permetant
+	 *										de créer de nouveau tag pour le type
+	 *										est affiché ainsi que le bouton pour
+	 *										éditer chaque tags individuellement.
+	 *									'show'		:
+	 *										Sur la fiche d'un élément, permet
+	 *										d'afficher la liste des tags lié.
+	 *										$toID doit valoir l'id du propriétaire.
+	 *										Seul les tags apartenant au propriétaire
+	 *										sont affiché.
+	 *										propriétataire
+	 *									'select'	:
+	 *										Sur la fiche d'un élément quand la
+	 *										séléction de tag est activé, permet
+	 *										de séléctioner les tags à ajouter ou
+	 *										retirer sur l'élément. $toID doit
+	 *										valoir l'id du propriétaire. Tout
+	 *										les tag du type en question sont
+	 *										affichés. Le bouton de création de
+	 *										nouveau tag est afiché ainsi que le
+	 *										bouton pour éditer chaques tags
+	 *										individuelement et la checkbox
+	 *										permétant d'ajouter ou de retirer
+	 *										le tag sur un élément.
+	 *									'search'	:
+	 *										Forumlaire de recheche relatif au
+	 *										type, permet de filter les résultat
+	 *										de la recherche en fonction des tags
+	 *										séléctionées. $toID doit valoir `0`.
+	 *										La chekck box permetant de séléctioner
+	 *										les tags sur les quel filter la recherche
+	 *										est affiché.
+	 *	@return		string			HTML avec la liste des tags.
+	 */
+	public static function getListHtml(int $typeID, int $toID, string $contexte)
+	{
+		global $p;
+		if (empty($p['page'])) $p['page'] = array();
+		if (empty($p['page']['univTags'])) $p['page']['univTags'] = array();
+		$p['page']['univTags']['typeID'] = $typeID;
+		$p['page']['univTags']['toID'] = $toID;
+		switch ($contexte) {
+			case 'config':
+				if ($toID > 0) throw new Exception(__METHOD__.' : $toID doit valoir 0 sur le contexte "config"');
+				$p['page']['univTags']['showEditBtn'] = true;
+				$p['page']['univTags']['showNewBtn'] = true;
+				$p['page']['univTags']['showSelectSetTo'] = false;
+				$p['page']['univTags']['showSelectFilterSearch'] = false;
+				$onlyTo = false;
+				break;
+			case 'show':
+				if ($toID < 1) throw new Exception(__METHOD__.' : $toID ne peut valloir 0 sur le contexte "show"');
+				$p['page']['univTags']['showEditBtn'] = false;
+				$p['page']['univTags']['showNewBtn'] = false;
+				$p['page']['univTags']['showSelectSetTo'] = false;
+				$p['page']['univTags']['showSelectFilterSearch'] = false;
+				$onlyTo = true;
+				break;
+			case 'select':
+				if ($toID < 1) throw new Exception(__METHOD__.' : $toID ne peut valloir 0 sur le contexte "select"');
+				$p['page']['univTags']['showEditBtn'] = self::checkTypeDroitCreSup($typeID);
+				$p['page']['univTags']['showNewBtn'] = self::checkTypeDroitCreSup($typeID);
+				$p['page']['univTags']['showSelectSetTo'] = self::checkTypeDroitAjoRet($typeID);
+				$p['page']['univTags']['showSelectFilterSearch'] = false;
+				$onlyTo = false;
+				break;
+			case 'search':
+				if ($toID > 0) throw new Exception(__METHOD__.' : $toID doit valoir 0 sur le contexte "search"');
+				$p['page']['univTags']['showEditBtn'] = false;
+				$p['page']['univTags']['showNewBtn'] = false;
+				$p['page']['univTags']['showSelectSetTo'] = false;
+				$p['page']['univTags']['showSelectFilterSearch'] = true;
+				$onlyTo = false;
+				break;
+			default:
+				throw new Exception(__METHOD__.' : contexte='.$contexte.' inconus');
+		}
+		$p['page']['univTags']['contexte'] = $contexte;
+		$p['page']['univTags']['tagListe'] = msUnivTags::getList($typeID, $toID, $onlyTo);
+		$getHtml = new msGetHtml();
+		$getHtml->set_template('unviTagsTagListe');
+		return $getHtml->genererHtml();
+	}
+
+	/**
+	 * Retourne le HTML pour la modal permetant de créer ou éditer un tag.
+	 * @param	int		$typeID		ID du type de tag.
+	 * @param	int		$tagID		ID du tag à éditer, si c'est un création
+	 *								doit valoir `0`.
+	 * @param	int		$toID		Si la modal est apelé depuis la fiche d'un
+	 *								élément doit avoir l'id de cette élément.
+	 *								Si la modal est apelé depuis un contexte
+	 *								général comme la page de configuration doit
+	 *								valoir `0`. Permet de faire suive le
+	 *								propriétaire du tage à la validation du
+	 *								formulaire pour générer la liste actualisé
+	 *								adéquate.
+	 * @param	string	$contexte	Contexte dans le quel la modal est apelé.
+	 *								Doit corespondre aux contexte de la méthode
+	 *								`getListHtml()`. Permet de faire suive le
+	 *								contexte à la validation du formulaire pour
+	 *								génére la liste actualisé adéquate.
+	 */
+	public static function getModalHtml(int $typeID, int $tagID, int $toID, $contexte)
+	{
+		global $p;
+		if (empty($p['page'])) $p['page'] = array();
+		if (empty($p['page']['univTags'])) $p['page']['univTags'] = array();
+		$p['page']['univTags']['typeID'] = $typeID;
+		$p['page']['univTags']['tagID'] = $tagID;
+		$p['page']['univTags']['toID'] = $toID;
+		$p['page']['univTags']['contexte'] = $contexte;
+		$p['page']['univTags']['typeName'] = self::getTypeNameById($typeID);
+		// Si le tagID est supérieur à 0 fetch le tag pour récupérer ses propriété
+		$p['page']['univTags']['tagListe'] = msUnivTags::getList($typeID);
+		if ($tagID > 0) {
+			$tag = new self;
+			$tagProp = $tag->fetch($tagID);
+			$p['page']['univTags']['tagProp'] = $tagProp;
+		}
+		$p['page']['univTags']['typeDroitCreSup'] = self::checkTypeDroitCreSup($typeID);
+		$getHtml = new msGetHtml();
+		$getHtml->set_template('univTagsTagModal');
+		return $getHtml->genererHtml();
+	}
+
+	/**
+	 * Obtenir le HTML générant une liste de pastilles colorées afin d'avoir
+	 * un vue compacte des tags atacĥées sur un élément.
+	 * @param	array	$list	Array de tags atachés à l'élément. Doit
+	 *							corespondre à ce que produit la méthode
+	 *							la méthode `getList()`.
+	 * @return	string			HTML.
+	public static function getTagsCircleHtml(array $list)
+	{
+		$ret = '';
+		// @TODO check list content
+		if (!empty($list)) {
+			foreach ($list as $tag) {
+				$ret .= '<span title="'.$tag['name'].' : '.$tag['description'].'" data-typeID="'.$tag['typeID'].'" data-toID="'.$tag['toID'].'">';
+				$ret .= '<svg height="22" width="22">';
+				$ret .= '<circle cx="11" cy="11" r="10" stroke="#B3B3B3" stroke-width="1" fill="'.$tag['color'].'" />';
+				$ret .= '</svg>';
+				$ret .= '</span>';
+			}
+		}
+		return $ret;
+	}
+
+	/********************************
+	 * Méthodes outils
+	 *******************************/
+
+	/**
+	 * Retourne la couleur noire ou blache en héxadécimal selon la
+	 * luminosité de la couleur héxadécimal passé en argument.
+	 * @param	string		$color	Couleur à analyser au format héxadécimal
+	 *								(#FFFFFF).
+	 * @return	string				Couleur noire ou blache en héxadécimal.
+	 */
+	private static function tagTextColor(string $color) {
+		$r = hexdec(substr($color, 1, 2));
+		$b = hexdec(substr($color, 3, 2));
+		$g = hexdec(substr($color, 5, 2));
+		$max = max($r, $g, $b);
+		$min = min($r, $g, $b);
+		$l = ($max + $min) /2;
+		if ($l > 120) return '#000000';
+		else return '#FFFFFF';
+	}
+
+}
+

--- a/class/msUnivTags.php
+++ b/class/msUnivTags.php
@@ -112,6 +112,21 @@ Class msUnivTags {
 	private $_droitAjoRet;
 
 	/**
+	 * Vérifier si un tag ne possède pas déjà un nom pour un même typeId
+	 * (le name doit être unique pour un typeID donnée).
+	 * @return	bool	`true` si le nom existe autrement `false`
+	 */
+	private function checkTypeNameExist()
+	{
+		if (empty($this->_typeID)) throw new Exception(__METHOD__.' : $this->_typeID non définit');
+		if (empty($this->_name)) throw new Exception(__METHOD__.' : $this->_name non définit');
+		$sql = 'SELECT `id` FROM '.self::TABLE_TAGS.' WHERE `name` = "'.$this->_name.'" AND `typeID` = "'.$this->_typeID.'"';
+		$resql = msSQL::sqlQuery($sql);
+		if (empty($resql)) throw new Exception(__METHOD__.' : erreur sql sur la vérification de l\'exisance du typeID');
+		return ($resql->num_rows > 0);
+	}
+
+	/**
 	 * Céer un nouveau TAG en fonction des propriétés définies.
 	 * @return Array	Tableau des propriété du tag nouvellement créé.
 	 */
@@ -122,11 +137,7 @@ Class msUnivTags {
 		if (empty($this->_color)) throw new Exception(__METHOD__.' : $this->_color non définit');
 
 		// Vérifie si aucun autre tag commporte le name avec ce typeID
-		// (le name doit être unique pour un typeID donnée)
-		$sql = 'SELECT `id` FROM '.self::TABLE_TAGS.' WHERE `name` = "'.$this->_name.'" AND `typeID` = "'.$this->_typeID.'"';
-		$resql = msSQL::sqlQuery($sql);
-		if (empty($resql)) throw new Exception(__METHOD__.' : erreur sql sur la vérification de l\'exisance du typeID');
-		else if ($resql->num_rows > 0) throw new Exception('Une étiquette portant déjà ce nom existe pour ce type.');
+		if ($this->checkTypeNameExist()) throw new Exception('Une étiquette portant déjà ce nom existe pour ce type.');
 
 		$data = array(
 			'typeID' => $this->_typeID,
@@ -145,6 +156,9 @@ Class msUnivTags {
 	 */
 	public function update() {
 		if (empty($this->_id)) throw new Exception(__METHOD__.' : $this->_id non définit');
+
+		// Vérifie si aucun autre tag commporte le name avec ce typeID
+		if ($this->checkTypeNameExist()) throw new Exception('Une étiquette portant déjà ce nom existe pour ce type.');
 
 		$data = msSQL::cleanArray(array(
 			'name' => $this->_name,

--- a/config/routes/routes-configuration.yml
+++ b/config/routes/routes-configuration.yml
@@ -81,6 +81,9 @@ configUserTemplatesEdit: ['GET', '/configuration/user-templates/edit/[*:fichier]
 # configuration crons
 configCron: ['GET', '/configuration/cron/', 'configuration/configCronJobs']
 
+# configuration pour les tags universelle
+configTags: ['GET', '/configuration/tags/', 'configuration/configUnivTags']
+
 # configuration apply updates
 configUpdates: ['GET', '/configuration/applyUpdates/', 'configuration/configApplyUpdates']
 

--- a/config/routes/routes-univtags.yml
+++ b/config/routes/routes-univtags.yml
@@ -1,8 +1,7 @@
 #
 # This file is part of MedShakeEHR.
 #
-# Copyright (c) 2017
-# Bertrand Boutillier <b.boutillier@gmail.com>
+# Copyright (c) 2021      DEMAREST Maxime <maxime@indelog.fr>
 # http://www.medshake.net
 #
 # MedShakeEHR is free software: you can redistribute it and/or modify
@@ -18,23 +17,16 @@
 # You should have received a copy of the GNU General Public License
 # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
 #
+#######################################
+#
+# @author DEMAREST Maxime <maxime@indelog.fr>
 #
 #######################################
 #
-# Routes : inclusion de jeux de routes suivant paramètres de configuration
-# (si true inclusion)
+# Routes : univtags
 #
 #######################################
 
-optionGeActiverAgenda: agenda
-optionGeActiverApiRest: apiRest
-optionGeActiverCompta: compta
-optionGeActiverDicom: dicom
-optionGeActiverDropbox: dropbox
-optionGeActiverGroupes: groupes
-optionGeActiverInboxApicrypt: inbox
-optionGeActiverLapInterne: lapInterne
-optionGeActiverPhonecapture: phonecapture
-optionGeActiverRegistres: registres
-optionGeActiverTransmissions: transmissions
-optionGeActiverUnivTags: univtags
+# tags universel
+univtagsConfig: ['GET', '/univtags/config/', 'univtags/config']
+univtagsAjax: ['GET|POST', '/univtags/ajax/[a:a]/', 'univtags/ajax']

--- a/controlers/patient/patient.php
+++ b/controlers/patient/patient.php
@@ -185,3 +185,14 @@ if($p['config']['optionGeActiverCompta'] == 'true') {
   $data=new msData;
   $p['page']['formReglement']=$data->getDataTypesFromNameList(explode(',',$p['config']['administratifReglementFormulaires']), array('id', 'module', 'label', 'description', 'formValues'));
 }
+
+// Tag universel pour le dossier médical d'un patient
+if ($p['config']['optionGeActiverUnivTags'] == 'true') {
+	$univTagsTypeID = msUnivTags::getTypeIdByName('patients');
+	$univTagsTypeActif = msUnivTags::getIfTypeIsActif($univTagsTypeID);
+	if ($univTagsTypeActif) {
+		$p['page']['univTagsListHtml'] = msUnivTags::getListHtml($univTagsTypeID, $p['page']['patient']['id'], 'show');
+		$p['page']['univTags']['typeDroitAjoRet'] = msUnivTags::checkTypeDroitAjoRet($univTagsTypeID);
+		$p['page']['univTags']['typeDroitCreSup'] = msUnivTags::checkTypeDroitCreSup($univTagsTypeID);
+	}
+}

--- a/controlers/people/proView.php
+++ b/controlers/people/proView.php
@@ -2,7 +2,7 @@
 /*
  * This file is part of MedShakeEHR.
  *
- * Copyright (c) 2017
+ * Copyright (c) 2017-2021
  * Bertrand Boutillier <b.boutillier@gmail.com>
  * http://www.medshake.net
  *
@@ -23,7 +23,8 @@
 /**
  * people : voir les infos sur un pro
  *
- * @author Bertrand Boutillier <b.boutillier@gmail.com>
+ * @author	Bertrand Boutillier <b.boutillier@gmail.com>
+ * @contrib	DEMAREST Maxime		<maxime@indelog.fr>
  */
 
 $debug='';
@@ -103,4 +104,15 @@ if($p['config']['optionGeActiverRegistres'] == 'true') {
 
 if($p['config']['droitDossierPeutTransformerPraticienEnUtilisateur'] == 'true') {
   $p['page']['loginUsername'] = msUser::makeRandomUniqLoginUsername(@$p['page']['proData']['firstname'], @$p['page']['proData']['lastname'], @$p['page']['proData']['birthname']);
+}
+
+// Tag universel pour une fiche pro
+if ($p['config']['optionGeActiverUnivTags'] == 'true') {
+	$univTagsTypeID = msUnivTags::getTypeIdByName('pros');
+	$univTagsTypeActif = msUnivTags::getIfTypeIsActif($univTagsTypeID);
+	if ($univTagsTypeActif) {
+		$p['page']['univTagsListHtml'] = msUnivTags::getListHtml($univTagsTypeID, $p['page']['proDataID'], 'show');
+		$p['page']['univTags']['typeDroitAjoRet'] = msUnivTags::checkTypeDroitAjoRet($univTagsTypeID);
+		$p['page']['univTags']['typeDroitCreSup'] = msUnivTags::checkTypeDroitCreSup($univTagsTypeID);
+	}
 }

--- a/controlers/rechercher/actions/inc-ajax-patientsListByCrit.php
+++ b/controlers/rechercher/actions/inc-ajax-patientsListByCrit.php
@@ -49,8 +49,20 @@ if ($_POST['porp']=='patient' or $_POST['porp']=='externe' or $_POST['porp']=='t
     $docAsSigner->setFromID($p['user']['id']);
     $p['page']['modelesDocASigner']=$docAsSigner->getPossibleDocToSign();
 
+	// intégration tags universel
+	if ($p['config']['optionGeActiverUnivTags'] == 'true') {
+		$univTagsTypeID = msUnivTags::getTypeIdByName('patients');
+		if (!msUnivTags::getIfTypeIsActif($univTagsTypeID)) unset($univTagsTypeID);
+	}
+
 } elseif ($_POST['porp']=='pro') {
     $formIN=$p['config']['formFormulaireListingPraticiens'];
+
+	// intégration tags universel
+	if ($p['config']['optionGeActiverUnivTags'] == 'true') {
+		$univTagsTypeID = msUnivTags::getTypeIdByName('pros');
+		if (!msUnivTags::getIfTypeIsActif($univTagsTypeID)) unset($univTagsTypeID);
+	}
 } elseif ($_POST['porp']=='groupe') {
     $formIN=$p['config']['formFormulaireListingGroupes'];
 } elseif ($_POST['porp']=='registre') {
@@ -228,5 +240,36 @@ if ($form=msForm::getFormUniqueRawField($formIN, 'yamlStructure')) {
                 $p['page']['outputType'][$patientID]['isUser']=$data[$patientID]['isUser'];
             }
         }
+
+		// Insert les tags universelle si ils sont actif et le type de tag concerné est actif
+		if (!empty($univTagsTypeID)) {
+			$p['page']['outputTableHead'][] = 'Étiquettes';
+			if (!empty($_POST['univTagsFilter'])) $univTagsFilter = array_column($_POST['univTagsFilter'], 'value');
+
+			foreach ($p['page']['outputTableRow'] as $k=>$v) {
+				$univTagsList = msUnivTags::getList($univTagsTypeID, $k, true);
+				sort($univTagsList);
+
+				// Filtre les résultat de la recherche en fonction des tags séléctionés
+				if (!empty($univTagsFilter)) {
+					$univTagsTagIDs = array_column($univTagsList, 'id');
+					sort($univTagsTypeID);
+					$univTagsInFliter = array_intersect($univTagsFilter, $univTagsTagIDs);
+					if ($univTagsFilter != $univTagsInFliter) { // ceci fait un et à la séléction
+						unset($p['page']['outputTableRow'][$k]);
+						continue;
+					}
+					// TODO faut il impementer un "ou" pour la séléction
+					//if (empty($univTagsInFliter)) { // ceci fait un ou à la séléction
+						//unset($p['page']['outputTableRow'][$k]);
+						//continue;
+					//}
+				}
+				$p['page']['outputTableRow'][$k][] = '<span>'.msUnivTags::getTagsCircleHtml($univTagsList).'</span>';
+			}
+			// Si pas de résultat purge l'entête du tableau pour afficher le message de résultat non trouvé
+
+			if (empty($p['page']['outputTableRow'])) unset($p['page']['outputTableHead']);
+		}
     }
 }

--- a/controlers/rechercher/peopleSearch.php
+++ b/controlers/rechercher/peopleSearch.php
@@ -2,7 +2,7 @@
 /*
  * This file is part of MedShakeEHR.
  *
- * Copyright (c) 2017
+ * Copyright (c) 2017-2021
  * Bertrand Boutillier <b.boutillier@gmail.com>
  * http://www.medshake.net
  *
@@ -23,8 +23,9 @@
 /**
  * Patients : listing patients ou pros
  *
- * @author Bertrand Boutillier <b.boutillier@gmail.com>
- * @contrib fr33z00 <https://github.com/fr33z00>
+ * @author	Bertrand Boutillier <b.boutillier@gmail.com>
+ * @contrib fr33z00				<https://github.com/fr33z00>
+ * @contrib DEMAREST Maxime		<maxime@indelog.fr>
  */
 
 $debug='';
@@ -108,4 +109,19 @@ if (msUser::checkUserIsAdmin() and in_array($p['page']['porp'], ['patient', 'pro
     $formModal->setFieldAttrAfterwards($p['page']['formModal'], 'password', ['required'=>'required']);
   }
   $formModal->addHiddenInput($p['page']['formModal'], ['preUserID'=>'']);
+}
+
+// Filtre de recherche avec les TAGs universel
+if ($p['config']['optionGeActiverUnivTags'] == 'true') {
+	$p['page']['univTags'] = array();
+	switch ($p['page']['porp']) {
+		case 'patient':
+			$p['page']['univTags']['typeID'] = msUnivTags::getTypeIdByName('patients');
+			break;
+		case 'pro':
+			$p['page']['univTags']['typeID'] = msUnivTags::getTypeIdByName('pros');
+			break;
+	}
+	if (! empty($p['page']['univTags']['typeID']) && msUnivTags::getIfTypeIsActif($p['page']['univTags']['typeID']))
+		$p['page']['univTags']['filterSearchHTML'] = msUnivTags::getListHtml($p['page']['univTags']['typeID'], 0, 'search');
 }

--- a/controlers/univtags/ajax.php
+++ b/controlers/univtags/ajax.php
@@ -1,0 +1,303 @@
+<?php
+/*
+ * This file is part of MedShakeEHR.
+ *
+ * Copyright (c) 2021      DEMAREST Maxime <maxime@indelog.fr>
+ * http://www.medshake.net
+ *
+ * MedShakeEHR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * MedShakeEHR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Config : ajax pour gestion des tags universel
+ *
+ * @author DEMAREST Maxime <maxime@indelog.fr>
+ */
+
+function returnJson(bool $status, string $message, array $data = []) {
+	header('Content-Type: application/json');
+	header('Cache-Control: no-store');
+	$ret = array(
+		'status' => $status ? 'ok' : 'error',
+		'message' => $message,
+		'data' => $data,
+	);
+    print json_encode($ret);
+	exit();
+}
+
+$action=$match['params']['a'];
+$gump = new GUMP('fr');
+
+switch ($action) {
+
+	case 'toggleTypeActif':
+		// Seul un administrateur peut désactiver un type de tag
+		if (!msUser::checkUserIsAdmin()) returnJson(false, 'Erreur: vous n\'êtes pas administrateur ou autorisé à effectuer cette action');
+		$validator = new Gump('fr');
+		$gump->validation_rules(array(
+			'typeID' => 'required|numeric',
+			'actif' => 'required|boolean',
+		));
+		$data = $gump->run($_POST);
+		if ($data) {
+			try {
+				$newState = msUnivTags::setTypeActif($data['typeID'], filter_var($data['actif'], FILTER_VALIDATE_BOOLEAN));
+				returnJson(true, 'Type de tag universel avec ID='.$data['typeID'].' '.($newState ? 'activé' : 'désactivé').'.', array('actif'=>$newState));
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'newTag':
+		$gump->validation_rules(array(
+			'name' => 'required|max_len,64',
+			'description' => 'required|max_len,256',
+			'color' => 'required|regex,/^#[0-9A-Fa-f]{6}$/',
+			'typeID' => 'required|numeric',
+			'toID' => 'required|numeric',
+			'contexte' => 'required|alpha',
+		));
+		$gump->filter_rules(array(
+			'name' => 'trim|sanitize_string',
+			'description' => 'trim|sanitize_string',
+		));
+		$data = $gump->run($_POST);
+		if ($data) {
+			try {
+				if (! msUnivTags::checkTypeDroitCreSup($data['typeID'])) throw new Exception('L\'utilisateur n\'est pas autorisé à effectuer cette action.');
+				$univTag = new msUnivTags();
+				$newTagTypeID = $univTag->setTypeID($data['typeID']);
+				$newTagName = $univTag->setName($data['name']);
+				$newTagDescription = $univTag->setDescription($data['description']);
+				$newTagColor = $univTag->setColor($data['color']);
+				$newTagID = $univTag->create();
+				$retData = array(
+					'id' => $newTagID,
+					'name' => $newTagName,
+					'description' => $newTagDescription,
+					'color' => $newTagColor,
+					'typeID' => $newTagTypeID,
+					'toID' => $data['toID'],
+					'tagsListHtml' => msUnivTags::getListHtml($newTagTypeID, $data['toID'], $data['contexte']),
+				);
+				returnJson(true, 'Tag crée', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'editTag':
+		$gump->validation_rules(array(
+			'id' => 'required|numeric',
+			'toID' => 'required|numeric',
+			'name' => 'required|max_len,64',
+			'description' => 'required|max_len,256',
+			'color' => 'required|regex,/^#[0-9A-Fa-f]{6}$/',
+			'contexte' => 'required|alpha',
+		));
+		$gump->filter_rules(array(
+			'name' => 'trim|sanitize_string',
+			'description' => 'trim|sanitize_string',
+		));
+		$data = $gump->run($_POST);
+		if ($data) {
+			try {
+				$univTag = new msUnivTags();
+				$univTag->fetch($data['id']);
+				if (! $univTag->checkDroitCreSup()) throw new Exception('L\'utilisateur n\'est pas autorisé à effectuer cette action.');
+				$newTagName = $univTag->setName($data['name']);
+				$newTagDescription = $univTag->setDescription($data['description']);
+				$newTagColor = $univTag->setColor($data['color']);
+				$univTag->update();
+				$retData = array(
+					'id' => $data['id'],
+					'name' => $newTagName,
+					'description' => $newTagDescription,
+					'color' => $newTagColor,
+					'typeID' => $univTag->getTypeID(),
+					'toID' => $data['toID'],
+					'tagsListHtml' => msUnivTags::getListHtml($univTag->getTypeID(), $data['toID'], $data['contexte']),
+				);
+				returnJson(true, 'Tag modifié', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'delTag':
+		$gump->validation_rules(array(
+			'id' => 'required|numeric',
+			'toID' => 'required|numeric',
+			'contexte' => 'required|alpha',
+		));
+		$data = $gump->run($_POST);
+		if ($data) {
+			try {
+				$univTag = new msUnivTags();
+				$univTag->fetch($data['id']);
+				if (! $univTag->checkDroitCreSup()) throw new Exception('L\'utilisateur n\'est pas autorisé à effectuer cette action.');
+				$typeID = $univTag->getTypeID();
+				$univTag->delete();
+				$retData = array(
+					'typeID' => $typeID,
+					'toID' => $data['toID'],
+					'tagsListHtml' => msUnivTags::getListHtml($typeID, $data['toID'], $data['contexte']),
+				);
+				returnJson(true, 'Tag suprimé', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'getTagsList':
+		$gump->validation_rules(array(
+			'typeID' => 'required|numeric',
+			'toID' => 'required|numeric',
+			'contexte' => 'required|alpha',
+		));
+		$data = $gump->run($_GET);
+		if ($data) {
+			try {
+				$retData = array(
+					'typeID' => $data['typeID'],
+					'toID' => $data['toID'],
+					'contexte' => $data['contexte'],
+					'tagsListHtml' => msUnivTags::getListHtml($data['typeID'], $data['toID'], $data['contexte']),
+				);
+				returnJson(true, 'Liste actualisé', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'getModalTag':
+		$gump->validation_rules(array(
+			'typeID' => 'required|numeric',
+			'tagID' => 'required|numeric',
+			'toID' => 'required|numeric',
+			'contexte' => 'required|alpha',
+		));
+		$data = $gump->run($_GET);
+		if ($data) {
+			try {
+				$modalHTML = msUnivTags::getModalHtml($data['typeID'], $data['tagID'], $data['toID'], $data['contexte']);
+				$retData = array(
+					'typeID' => $data['typeID'],
+					'tagID' => $data['tagID'],
+					'toID' => $data['toID'],
+					'contexte' => $data['toID'],
+					'modalHTML' => $modalHTML,
+				);
+				returnJson(true, 'Modal UnivTag obtenu', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'getSelectForm':
+		$gump->validation_rules(array(
+			'typeID' => 'required|numeric',
+			'toID' => 'required|numeric',
+		));
+		$data = $gump->run($_GET);
+		if ($data) {
+			try {
+				$selectFormHTML = msUnivTags::getSelectFormHtml($data['typeID'], $data['toID']);
+				$retData = array(
+					'toID' => $data['toID'],
+					'selectFormHTML' => $selectFormHTML,
+				);
+				returnJson(true, 'Formulaire de séléction obtenus', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'setTagTo':
+		$gump->validation_rules(array(
+			'toID' => 'required|numeric',
+			'tagID' => 'required|numeric',
+		));
+		$data = $gump->run($_POST);
+		if ($data) {
+			try {
+				$univTag = new msUnivTags();
+				$univTag->fetch($data['tagID']);
+				if (!$univTag->checkDroitAjoRet()) throw new Exception('L\'utilisateur n\'est pas autorisé à effectuer cette action');
+				$toID = $univTag->setTagTo($data['toID']);
+				$retData = array(
+					'typeID' => $univTag->getTypeID(),
+					'tagIDs' => $univTag->getID(),
+					'toID' => $toID,
+				);
+				returnJson(true, 'Tags ataché', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	case 'removeTagTo':
+		$gump->validation_rules(array(
+			'toID' => 'required|numeric',
+			'tagID' => 'required|numeric',
+		));
+		$data = $gump->run($_POST);
+		if ($data) {
+			try {
+				$univTag = new msUnivTags();
+				$univTag->fetch($data['tagID']);
+				if (!$univTag->checkDroitAjoRet()) throw new Exception('L\'utilisateur n\'est pas autorisé à effectuer cette action');
+				$toID = $univTag->removeTagTo($data['toID']);
+				$retData = array(
+					'typeID' => $univTag->getTypeID(),
+					'tagIDs' => $univTag->getID(),
+					'toID' => $toID,
+				);
+				returnJson(true, 'Étiquette retirée', $retData);
+			} catch (Exception $e) {
+				returnJson(false, $e->getMessage());
+			}
+		} else {
+			returnJson(false, $gump->get_readable_errors(true));
+		}
+		break;
+
+	default:
+		returnJson(false, 'action non prise en charge');
+}

--- a/controlers/univtags/config.php
+++ b/controlers/univtags/config.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * This file is part of MedShakeEHR.
+ *
+ * Copyright (c) 2021      DEMAREST Maxime <maxime@indelog.fr>
+ * http://www.medshake.net
+ *
+ * MedShakeEHR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * MedShakeEHR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Config : gérer les tags universelle
+ *
+ * @author DEMAREST Maxime <maxime@indelog.fr>
+ */
+
+ //admin uniquement
+if (!msUser::checkUserIsAdmin()) {
+    $template="forbidden";
+    return;
+}
+
+$template='univTagsConfig';
+$debug='';
+
+$p['page']['univTagsTypeList'] = msUnivTags::getTypeList();

--- a/public_html/css/univtags.css
+++ b/public_html/css/univtags.css
@@ -1,0 +1,22 @@
+/* CSS pour les tags universel */
+
+.univTagsTableLineType:hover {
+	cursor: pointer;
+}
+
+.univTagsTag {
+	border: 0.1em solid #6D6D6D;
+	border-radius: 10px 0px 10px 0px;
+	box-shadow: 0.1em 0.3em 0.3em #555;
+}
+
+.univTagsTagEditBtn {
+	color: inherit;
+	background-color: inherit;
+	border: none;
+	padding: 0;
+}
+
+#univTagsContainer .dropdown{
+	width: 100%;
+}

--- a/public_html/js/rechercher.js
+++ b/public_html/js/rechercher.js
@@ -329,6 +329,7 @@ function selectListingRow(listingRow) {
  * @return {void}
  */
 function updateListingPatients() {
+  var univTagsFilter = $('.univTagsSelectFilter').serializeArray();
   $.ajax({
     url: urlBase + '/patients/ajax/patientsListByCrit/',
     type: 'post',
@@ -339,6 +340,7 @@ function updateListingPatients() {
       autreCrit: $('#autreCrit option:selected').val(),
       autreCritVal: $('#autreCritVal').val(),
       patientsPropres: $('#patientsPropres').is(':checked'),
+	  univTagsFilter: univTagsFilter,
     },
     dataType: "html",
     success: function(data) {

--- a/public_html/js/univtags/config.js
+++ b/public_html/js/univtags/config.js
@@ -1,0 +1,115 @@
+/*
+ * This file is part of MedShakeEHR.
+ *
+ * Copyright (c) 2021      DEMAREST Maxime <maxime@indelog.fr>
+ * http://www.medshake.net
+ *
+ * MedShakeEHR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * MedShakeEHR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Fonctions JS pour la page de configuration des tags universel
+ *
+ * @author DEMAREST Maxime <maxime@indelog.fr>
+ */
+
+/**
+ * Active ou désactive un tag en fonction de l'état d'une checkbox
+ * @param	int		typeID		ID du type à activer
+ * @param	object  chkbx		Element du DOM contenant la checkbox
+ *								activant ou désactivant le tag.
+ * @return	void
+ */
+function univTagsConfigSetTypeActif(typeID, chkbx) {
+	var confirmOK = confirm('Confirmer vous la '+(chkbx.checked ? 'l\'activation' : 'désactivation')+' du type de tag avec l\'ID #'+typeID+' ?');
+	if (confirmOK) {
+		$.ajax({
+			type: 'POST',
+			url: urlBase + '/univtags/ajax/toggleTypeActif/',
+			data: {
+				typeID: typeID,
+				actif: chkbx.checked,
+			},
+			dataType: 'json',
+			success: function(data) {
+				if (data.status === 'ok') {
+					alert_popup('success', data.message);
+				} else {
+					alert_popup('danger', data.message);
+					// annule le chegement d'état de la checkbox
+					chkbx.checked = !chkbx.checked;
+				};
+			},
+			error: function(data) {
+				alert_popup('danger', 'Problème, rechargez la page !');
+				// annule le chegement d'état de la checkbox
+				chkbx.checked = !chkbx.checked;
+			},
+		});
+	};
+
+	if (!confirmOK) {
+		// annule le chegement d'état de la checkbox
+		chkbx.checked = !chkbx.checked;
+	};
+}
+
+/**
+ * Obtenir la liste HTML des tags pour le type voulut.
+ * @param	int		typeID		ID du type.
+ * @param	object	elem		Elément ayant déclanché la demande de la
+ *								liste.
+ * @return	void
+ */
+function univTagsGetList(typeID, elem) {
+	isShowed = elem.dataset.showed;
+	$(elem).children().each(function() {$(this).toggleClass('d-none');});
+	var univTagsContainer = $('.univTagsContainer[data-typeID="'+typeID+'"]');
+	if (isShowed == 'true') {
+		univTagsContainer.empty();
+		univTagsContainer.addClass('d-none');
+		elem.dataset.showed = 'false';
+	} else {
+		$.ajax({
+			type: 'GET',
+			url: urlBase + '/univtags/ajax/getTagsList/',
+			data: {
+				typeID: typeID,
+				toID: 0,
+				contexte: 'config',
+			},
+			dataType: 'json',
+			success: function(data) {
+				if (data.status === 'ok') {
+					univTagsContainer.empty();
+					$(data.data.tagsListHtml).appendTo(univTagsContainer);
+					elem.dataset.showed = 'true';
+					console.log(elem);
+					univTagsContainer.removeClass('d-none');
+				} else {
+					alert_popup('danger', data.message);
+					$(elem).find('.fa-plus-square').toggleClass('d-none', true);
+					$(elem).find('.fa-minus-square').toggleClass('d-none', false);
+					univTagsContainer.addClass('d-none');
+				};
+			},
+			error: function(data) {
+				alert_popup('danger', 'Problème, rechargez la page !');
+				$(elem).find('.fa-plus-square').toggleClass('d-none', true);
+				$(elem).find('.fa-minus-square').toggleClass('d-none', false);
+				univTagsContainer.addClass('d-none');
+			},
+		});
+	}
+}

--- a/public_html/js/univtags/main.js
+++ b/public_html/js/univtags/main.js
@@ -1,0 +1,202 @@
+/*
+ * This file is part of MedShakeEHR.
+ *
+ * Copyright (c) 2021
+ * DEMAREST Maxime <b.boutillier@gmail.com>
+ * http://www.medshake.net
+ *
+ * MedShakeEHR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * MedShakeEHR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Fonctions JS relative aux tags universel
+ *
+ * @author DEMAREST Maxime <maxime@indelog.fr>
+ */
+
+/**
+ * Obtenir un modal de création ou de modification d'un tag universel.
+ * @param	int		typeID		ID du type de tag.
+ * @param	int		tagID		ID du tag, si création de nouveau tag doit
+ *								valoir `0`.
+ * @param	int		toID		Si la modal est apelé depuis la fiche d'un
+ *								élément doit être l'ID de cette élément. Sinon
+ *								si la modal est apelé depuis un autre contexte
+ *								commem la page de configuration général des
+ *								tags universel doit valoir `0`.
+ * @param	string	contexte	Le contexte dans le quel est apelé la modal.
+ *								Doit corresondre au contexte définit sur
+ *								`msUnivTags::getListHtml()`.
+ * @return	void
+ */
+function getModalUnivTag(typeID, tagID, toID, contexte) {
+  $('#modalUnivTag').remove();
+  $.ajax({
+    type: 'GET',
+    url: '/univtags/ajax/getModalTag/',
+    data: {
+      typeID: typeID,
+      tagID: tagID,
+      toID: toID,
+      contexte: contexte,
+    },
+    dataType: 'json',
+    success: function(data) {
+      switch (data.status) {
+        case 'ok':
+          $('body').append(data.data.modalHTML);
+          $('#modalUnivTag').modal('show');
+          $('#modalUnivTag').on('hidden.bs.modal', function(event) {$('#modalUnivTag').remove();});
+          break;
+        case 'error':
+          alert_popup('danger', data.message);
+          break;
+      };
+    },
+    error: function(data) {
+      alert_popup('danger', 'Problème, rechargez la page !');
+    },
+  });
+}
+
+/**
+ * Déclanche l'opération de cération ou de modificaton d'un tag universel.
+ * @param	object	btn		Élément de type `button` du DOM ayant déclancé
+ *							l'apel à la function.
+ * @param	bool	del		Si l'action vis la supression d'un tag, mette à
+ *							`true` autrement, pour la création ou la
+ *							modification d'un tag mettre à `false`.
+ * @return	void
+ */
+function formUnivTagValid(btn, del = false) {
+  var formDatas = $('#formUnivTag :input').serializeArray();
+  var tagID = formDatas.find((o) => {return o['name'] === 'id'}).value;
+  // action de supression du tag
+  if (del) {
+    var ok = confirm('Confirmer vous la demande de supression de cette étiquette (/!\\ elle sera retiré de tout les éléments au quel elle est atachée) ?');
+    if (!ok) { return null };
+    var action = 'delTag';
+  } else {
+    // si le tag id est 0 on créer un nouveau tag sinon c'est que l'on modifie un tag existant
+    var action = (tagID > 0) ? 'editTag' : 'newTag';
+  }
+  $.ajax({
+    type: 'POST',
+    url: '/univtags/ajax/'+action+'/',
+    data: formDatas,
+    dataType: 'json',
+    success: function(data) {
+      switch (data.status) {
+        case 'ok':
+          alert_popup('success', data.message);
+          $('#modalUnivTag').modal('hide');
+          // Actualise la liste des tags
+          var univTagsContainer = $('.univTagsContainer[data-typeID="'+data.data.typeID+'"]');
+          univTagsContainer.empty();
+          $(data.data.tagsListHtml).appendTo(univTagsContainer);
+          // sur la page de configuration des tags universelle passe les ligne du tableau
+          // relative au type de tag en visible
+          var showIndicator = $('.unviTagsTypeShowIndicator[data-typeID="'+data.data.typeID+'"]')
+          if (showIndicator.length > 0) {
+						showIndicator.data('showed', true);
+						showIndicator.find('.fa-plus-square').toggleClass('d-none', true);
+						showIndicator.find('.fa-minus-square').toggleClass('d-none', false);
+						univTagsContainer.removeClass('d-none');
+          }
+          break;
+        case 'error':
+          alert_popup('danger', data.message);
+          break;
+      };
+    },
+    error: function(data) {
+      alert_popup('danger', 'Problème, rechargez la page !');
+      $('#modalUnivTag').modal('hide');
+    },
+  });
+}
+
+/**
+ * Obtenir la le HTML pour la liste de tag.
+ * @param	int		typID		ID du type pour le quel obtenir la liste.
+ * @param	int		toID		ID de l'élément pour la quel obtenir la liste. Si
+ *								il n'y a pas d'élément déterminier pour le quel la
+ *								liste doit étre obtenus (ex contexte de configuration
+ *								général ou de recheche) mettre à `0`.
+ * @param	string	contexte	Contexte dans le quel la liste doit être obtenus.
+ *								Doit corresondre au contexte définit sur
+ *								`msUnivTags::getListHtml()`.
+ * @return	void								
+ */
+function getTagsList(typeID, toID, contexte) {
+  $.ajax({
+    type: 'GET',
+    url: '/univtags/ajax/getTagsList/',
+    data: {
+      typeID: typeID,
+      toID: toID,
+      contexte: contexte
+    },
+    dataType: 'json',
+    success: function(data) {
+      switch (data.status) {
+        case 'ok':
+            var univTagsContainer = $('.univTagsContainer[data-typeID="'+data.data.typeID+'"]');
+            univTagsContainer.empty();
+            $(data.data.tagsListHtml).appendTo(univTagsContainer);
+          break;
+        case 'error':
+          alert_popup('danger', data.message);
+          break;
+      };
+    },
+    error: function(data) {
+      alert_popup('danger', 'Problème, rechargez la page !');
+    },
+  });
+}
+
+/**
+ * Ajoute le tag à l'élément.
+ * @param	object		chkbx		Élément du DOM de type "checkbox" indiquant
+ *									si le tag est séléctioné ou non.
+ * @return	void
+ */
+function univTagsSetTo(chkbx) {
+  var tagID = chkbx.dataset.tagid;
+  var toID = chkbx.dataset.toid;
+  if (chkbx.checked) { var action = 'setTagTo'; }
+  else { var action = 'removeTagTo'; }
+  $.ajax({
+    type: 'POST',
+    url: '/univtags/ajax/'+action+'/',
+    data: {tagID: tagID, toID: toID},
+    dataType: 'json',
+    success: function(data) {
+      switch (data.status) {
+        case 'ok':
+          alert_popup('success', data.message);
+          break;
+        case 'error':
+          chkbx.checked = (!chkbx.checked);
+          alert_popup('danger', data.message);
+          break;
+      };
+    },
+    error: function(data) {
+      chkbx.checked = (!chkbx.checked);
+      alert_popup('danger', 'Problème, rechargez la page !');
+    },
+  });
+}

--- a/templates/base/configuration/configIndex.html.twig
+++ b/templates/base/configuration/configIndex.html.twig
@@ -115,6 +115,11 @@
         <li class="list-group-item">
           <a href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/configuration/cron/">Tâches planifiées</a>
         </li>
+        {% if config.optionGeActiverUnivTags == 'true' %}
+        <li class="list-group-item">
+          <a href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/univtags/config/">Tags universel</a>
+        </li>
+        {% endif %}
       </ul>
 
       <h2 class="mt-4 mb-2">Utilisateurs</h2>

--- a/templates/base/page/page.html.twig
+++ b/templates/base/page/page.html.twig
@@ -1,7 +1,7 @@
 {#
  # This file is part of MedShakeEHR.
  #
- # Copyright (c) 2017
+ # Copyright (c) 2017-2021
  # Bertrand Boutillier <b.boutillier@gmail.com>
  # http://www.medshake.net
  #
@@ -43,6 +43,9 @@
         {% block cssFiles %}
         <link href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/thirdparty/fortawesome/font-awesome/css/all.min.css" rel="stylesheet">
         <link type="text/css" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/scss/bs_custom.min.css" rel="stylesheet"/>
+        {% if config.optionGeActiverUnivTags == 'true' %}
+        <link type="text/css" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/css/univtags.css" rel="stylesheet"/>
+        {% endif %}
         <link type="text/css" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/thirdparty/eonasdan/bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css" rel="stylesheet"/>
         <link type="text/css" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/js/jquery-ui-1.12.1.custom/jquery-ui.min.css" rel="stylesheet"/>
         {% endblock %}
@@ -63,6 +66,9 @@
         <script defer src="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/thirdparty/lrsjng/kjua/dist/kjua.min.js?{{ modules.base }}"></script>
         <script defer src="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/thirdparty/joequery/stupid-table-plugin/stupidtable.min.js?{{ modules.base }}"></script>
         <script defer src="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/js/autosize.min.js?{{ modules.base }}"></script>
+        {% if config.optionGeActiverUnivTags == 'true' %}
+        <script defer src="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/js/univtags/main.js?{{ modules.base }}"></script>
+        {% endif %}
         {% endblock %}
 
         <script>

--- a/templates/base/patient/patientBase.html.twig
+++ b/templates/base/patient/patientBase.html.twig
@@ -1,7 +1,7 @@
 {#
  # This file is part of MedShakeEHR.
  #
- # Copyright (c) 2018
+ # Copyright (c) 2018-2021
  # Bertrand Boutillier <b.boutillier@gmail.com>
  # http://www.medshake.net
  #
@@ -23,8 +23,9 @@
  # Template > patient : dossier patient, structure de base étendue
  # par fichiers patient.html.twig des dossiers modules
  #
- # @author Bertrand Boutillier <b.boutillier@gmail.com>
- # @contrib fr33z00 <https://github.com/fr33z00>
+ # @author  Bertrand Boutillier <b.boutillier@gmail.com>
+ # @contrib fr33z00             <https://github.com/fr33z00>
+ # @contrib DEMAREST Maxime     <maxime@indelog.fr>
  #}
 
 {% extends "page.html.twig" %}
@@ -149,6 +150,24 @@
     {% endif %}">
       {% include('inc-ajax-patientAdminData.html.twig') %}
     </div>
+
+    {# univtag patient #}
+    {% if page.univTagsListHtml is not empty %}
+    <div class="card">
+      <div class="card-header d-flex flex-row justify-content-between">
+        <h5>Étiquette du patient</h5>
+        {% if page.univTags.typeDroitAjoRet %}
+        <div class="custom-control custom-switch">
+          <input id="univTagsSetTag" type="checkbox" class="custom-control-input" onclick="getTagsList({{ page.univTags.typeID }}, {{ page.univTags.toID }}, (this.checked ? 'select' : 'show'));" autocomplete="off">
+          <label class="custom-control-label" for="univTagsSetTag">Séléctioner des étiquettes</label>
+        </div>
+        {% endif %}
+      </div>
+      <div class="univTagsContainer" data-typeID="{{ page.univTags.typeID }}" class="card-body p-1">
+        {{ page.univTagsListHtml }}
+      </div>
+    </div>
+    {% endif %}
 
 {% endblock %}
 

--- a/templates/base/people/proView.html.twig
+++ b/templates/base/people/proView.html.twig
@@ -1,7 +1,7 @@
 {#
  # This file is part of MedShakeEHR.
  #
- # Copyright (c) 2017
+ # Copyright (c) 2017-2021
  # Bertrand Boutillier <b.boutillier@gmail.com>
  # http://www.medshake.net
  #
@@ -22,8 +22,10 @@
 /##
  # Template > people : voir les infos sur un pro
  #
- # @author Bertrand Boutillier <b.boutillier@gmail.com>
- # @contrib fr33z00 <https://github.com/fr33z00>
+ # @author  Bertrand Boutillier <b.boutillier@gmail.com>
+ # @contrib fr33z00             <https://github.com/fr33z00>
+ # @contrib DEMAREST Maxime     <maxime@indelog.fr>
+ #}
  #}
 
 {% extends "page.html.twig" %}
@@ -78,6 +80,25 @@
   {% endif %}
    <small class="text-muted">{{ page.proData.job }}</small>
 </h1>
+
+{# univtag pros #}
+{% if page.univTagsListHtml is not empty %}
+<div class="card">
+  <div class="card-header d-flex flex-row justify-content-between">
+    <h5>Étiquettes du professionel</h5>
+
+    {% if page.univTags.typeDroitAjoRet %}
+    <div class="custom-control custom-switch">
+      <input id="univTagsSetTag" type="checkbox" class="custom-control-input" onclick="getTagsList({{ page.univTags.typeID }}, {{ page.univTags.toID }}, (this.checked ? 'select' : 'show'));" autocomplete="off">
+      <label class="custom-control-label" for="univTagsSetTag">Séléctioner des étiquettes</label>
+    </div>
+    {% endif %}
+  </div>
+  <div class="univTagsContainer" data-typeID="{{ page.univTags.typeID }}" class="card-body p-1">
+    {{ page.univTagsListHtml }}
+  </div>
+</div>
+{% endif %}
 
 <div class="row mt-3">
   <div class="col-12 col-md-6">

--- a/templates/base/people/proView.html.twig
+++ b/templates/base/people/proView.html.twig
@@ -26,7 +26,6 @@
  # @contrib fr33z00             <https://github.com/fr33z00>
  # @contrib DEMAREST Maxime     <maxime@indelog.fr>
  #}
- #}
 
 {% extends "page.html.twig" %}
 {% import "macroForm.html.twig" as f %}

--- a/templates/base/rechercher/searchPeoplePatientsAndPros.html.twig
+++ b/templates/base/rechercher/searchPeoplePatientsAndPros.html.twig
@@ -1,7 +1,7 @@
 {#
  # This file is part of MedShakeEHR.
  #
- # Copyright (c) 2017
+ # Copyright (c) 2017-2021
  # Bertrand Boutillier <b.boutillier@gmail.com>
  # http://www.medshake.net
  #
@@ -22,8 +22,9 @@
 /##
  # Template > patients : listing recherche patients / pro
  #
- # @author Bertrand Boutillier <b.boutillier@gmail.com>
- # @contrib fr33z00 <https://github.com/fr33z00>
+ # @author  Bertrand Boutillier <b.boutillier@gmail.com>
+ # @contrib fr33z00             <https://github.com/fr33z00>
+ # @contrib DEMAREST Maxime     <maxime@indelog.fr>
  #}
 
 {% extends "page.html.twig" %}
@@ -68,123 +69,139 @@ associer patient
 {% endif %}
 
 <div class="card card-body bg-light my-4">
-	<div class="row ">
+  <form id="formRecherchePatients">
 
-	  <form id="formRecherchePatients" class="form-inline col-12 col-xl-9 mx-0 row my-xl-2">
-	    <div class="form-group col-12 my-2 my-xl-0 m-0 p-0 col-xl-2">
-	      {{ f.input ({
-		      'input' : {
-			      'type' : 'text',
-			      'id' : 'd2',
-			      'name' : 'lastname',
-	          'value' : (page.patient.administrativeDatas.lastname|default(page.patient.administrativeDatas.birthname|default('')))|trim,
-			      'placeholder' : 'Nom',
-			      'class' : 'form-control col-12 searchupdate',
-			      'autocomplete' : 'off',
-			      'datatypeid' : '2'
-		      },
-		      'label' : {
-			      'position' : 'before',
-		      }
-	      }) }}
-	    </div>
+    <div class="form-row mt-2">
+      {# Insertion des champ pour filter en fonction des tags universel #}
+      {% if page.univTags is not empty %}
+      <div class="d-flex flex-row">
+        <div class="p-2 font-italic">Filter les résultats en fonction des étiquettes séléctionées :</div>
+        <div class="univTagsContainer" data-typeID="{{ page.univTags.typeID }}">{{ page.univTags.filterSearchHTML }}</div>
+      </div>
+      {% endif %}
+    </div>
 
-			<div class="form-group col-12 my-2 my-xl-0 m-0 p-0 pl-xl-3 col-xl-2">
-				{{ f.input ({
-					'input' : {
-						'type' : 'text',
-						'id' : 'd3',
-						'name' : 'firstname',
-						'value' : page.patient.administrativeDatas.firstname|default(''),
-						'placeholder' : 'Prénom',
-						'class' : 'form-control col-12 searchupdate',
-						'autocomplete' : 'off',
-						'datatypeid' : '2'
-					},
-					'label' : {
-						'position' : 'before',
-					}
-				}) }}
-			</div>
+    <div class="form-row align-items-center">
 
-	    <div class="col-12 my-2 my-xl-0 mx-0 p-0 pl-xl-4 col-xl-5">
-	      <div class="input-group mx-0">
-	        {{ f.input ({
-	          'input' : {
-		          'id' : 'autreCritVal',
-		          'type' : 'text',
-		          'name' : 'autre',
-	            'placeholder': 'Autre critère',
-		          'class' : 'form-control searchupdate',
-							'autocomplete' : 'off',
-	          },
-	          'label' : {
-		          'position' : 'before',
-		          'label' : '',
-	          }
-	        }) }}
-	        <div class="input-group-append" style="max-width:50%">
-	          {{ f.selectOptgroup ({
-	            'select' : {
-		            'id' : 'autreCrit',
-		            'name' : 'autre',
-		            'class' : 'custom-select input-group-text form-control',
-		            'values' : page.tabTypes,
-	        	    'valueDefaut' : 'birthdate',
-								'autocomplete' : 'off',
-	            },
-	            'label' : {
-		            'position' : 'before',
-		            'label' : '',
-	            }
-	          }) }}
-	        </div>
-	      </div>
-	    </div>
-			<div class="col-12 col-xl-3 my-2 my-xl-0 mx-0 p-0 pl-xl-4">
-				<div class="custom-control custom-checkbox justify-content-start
-				{% if page.porp != 'patient' and config.droitDossierPeutVoirUniquementPatientsPropres != 'true' %}
-					d-none
-				{% endif %}
-				">
-  				<input type="checkbox" class="custom-control-input searchupdate" id="patientsPropres">
-  				<label style="justify-content: left" class="custom-control-label" for="patientsPropres">Patients propres uniquement</label>
-				</div>
-			</div>
-	  </form>
+      <div class="col-auto mt-2">
+        {{ f.input ({
+          'input' : {
+            'type' : 'text',
+            'id' : 'd2',
+            'name' : 'lastname',
+            'value' : (page.patient.administrativeDatas.lastname|default(page.patient.administrativeDatas.birthname|default('')))|trim,
+            'placeholder' : 'Nom',
+            'class' : 'form-control col-12 searchupdate',
+            'autocomplete' : 'off',
+            'datatypeid' : '2'
+          },
+          'label' : {
+            'position' : 'before',
+          }
+        }) }}
+      </div>
 
-	  <div class="col-12 col-xl-3 text-right my-xl-2">
+      <div class="col-auto mt-2">
+        {{ f.input ({
+          'input' : {
+            'type' : 'text',
+            'id' : 'd3',
+            'name' : 'firstname',
+            'value' : page.patient.administrativeDatas.firstname|default(''),
+            'placeholder' : 'Prénom',
+            'class' : 'form-control col-12 searchupdate',
+            'autocomplete' : 'off',
+            'datatypeid' : '2'
+          },
+          'label' : {
+            'position' : 'before',
+          }
+        }) }}
+      </div>
 
-	  {% if page.porp in ['patient', 'today'] %}
-			{% if page.porp == 'patient' and config.optionGeActiverVitaleLecture =='true' %}
-				<button type="button" class="btn btn-success lireCpsVitale"><i class="fas fa-user"></i> Vitale</button>
-			{% endif %}
-			<div class="btn-group  my-xl-1">
-	    	<a class="btn btn-primary" role="button" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/patient/create/"><i class="fas fa-plus"></i> Nouveau patient</a>
-				{% if config.droitDossierPeutSupPatient == 'true' %}
-					<button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	    			<span class="sr-only">Toggle Dropdown</span>
-				  </button>
-				  <div class="dropdown-menu dropdown-menu-right">
-				    <a class="dropdown-item" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/people/deleted/"><i class="fas fa-trash-restore fa-fw text-muted mr-1"></i>Récupérer un dossier supprimé</a>
-				  </div>
-				{% endif %}
-			</div>
-	  {% elseif page.porp == 'pro' and config.droitDossierPeutCreerPraticien == 'true' %}
-			<div class="btn-group my-lg-1">
-	    	<a class="btn btn-primary float-right" role="button" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/pro/create/"><i class="fas fa-plus"></i> Nouveau praticien</a>
-				{% if config.droitDossierPeutSupPraticien == 'true' %}
-					<button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						<span class="sr-only">Toggle Dropdown</span>
-					</button>
-					<div class="dropdown-menu dropdown-menu-right">
-						<a class="dropdown-item" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/people/deleted/"><i class="fas fa-trash-restore fa-fw text-muted mr-1"></i>Récupérer un dossier supprimé</a>
-					</div>
-				{% endif %}
-			</div>
-	  {% endif %}
-	  </div>
-	</div>
+      <div class="col-auto mt-2">
+        <div class="input-group">
+          {{ f.input ({
+            'input' : {
+              'id' : 'autreCritVal',
+              'type' : 'text',
+              'name' : 'autre',
+              'placeholder': 'Autre critère',
+              'class' : 'form-control searchupdate',
+              'autocomplete' : 'off',
+            },
+            'label' : {
+              'position' : 'before',
+              'label' : '',
+            }
+          }) }}
+          <div class="input-group-append" style="max-width:50%">
+            {{ f.selectOptgroup ({
+              'select' : {
+                'id' : 'autreCrit',
+                'name' : 'autre',
+                'class' : 'custom-select input-group-text form-control',
+                'values' : page.tabTypes,
+                'valueDefaut' : 'birthdate',
+                'autocomplete' : 'off',
+              },
+              'label' : {
+                'position' : 'before',
+                'label' : '',
+              }
+            }) }}
+          </div>
+        </div>
+      </div>
+
+      <div class="col-auto mt-2">
+          <div class="custom-control custom-checkbox justify-content-start
+          {% if page.porp != 'patient' and config.droitDossierPeutVoirUniquementPatientsPropres != 'true' %}
+              d-none
+          {% endif %}
+          ">
+          <input type="checkbox" class="custom-control-input searchupdate" id="patientsPropres">
+          <label style="justify-content: left" class="custom-control-label" for="patientsPropres">Patients propres uniquement</label>
+          </div>
+      </div>
+
+      <div class="col-auto mt-2 ml-auto">
+        {% if page.porp in ['patient', 'today'] %}
+          {% if page.porp == 'patient' and config.optionGeActiverVitaleLecture =='true' %}
+            <button type="button" class="btn btn-success lireCpsVitale"><i class="fas fa-user"></i> Vitale</button>
+          {% endif %}
+
+          <div class="btn-group  my-xl-1">
+            <a class="btn btn-primary" role="button" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/patient/create/"><i class="fas fa-plus"></i> Nouveau patient</a>
+            {% if config.droitDossierPeutSupPatient == 'true' %}
+              <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">Toggle Dropdown</span>
+              </button>
+              <div class="dropdown-menu dropdown-menu-right">
+                <a class="dropdown-item" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/people/deleted/"><i class="fas fa-trash-restore fa-fw text-muted mr-1"></i>Récupérer un dossier supprimé</a>
+              </div>
+            {% endif %}
+          </div>
+
+        {% elseif page.porp == 'pro' and config.droitDossierPeutCreerPraticien == 'true' %}
+
+          <div class="btn-group my-lg-1">
+            <a class="btn btn-primary float-right" role="button" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/pro/create/"><i class="fas fa-plus"></i> Nouveau praticien</a>
+            {% if config.droitDossierPeutSupPraticien == 'true' %}
+              <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">Toggle Dropdown</span>
+              </button>
+              <div class="dropdown-menu dropdown-menu-right">
+                <a class="dropdown-item" href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/people/deleted/"><i class="fas fa-trash-restore fa-fw text-muted mr-1"></i>Récupérer un dossier supprimé</a>
+              </div>
+            {% endif %}
+          </div>
+
+        {% endif %}
+
+      </div>
+    </div>
+  </form>
 </div>
 
 <div class="row mt-3">

--- a/templates/base/rechercher/searchPeoplePatientsAndPros.html.twig
+++ b/templates/base/rechercher/searchPeoplePatientsAndPros.html.twig
@@ -71,6 +71,7 @@ associer patient
 <div class="card card-body bg-light my-4">
   <form id="formRecherchePatients">
 
+    {% if page.univTags.filterSearchHTML is not empty %}
     <div class="form-row mt-2">
       {# Insertion des champ pour filter en fonction des tags universel #}
       {% if page.univTags is not empty %}
@@ -80,6 +81,7 @@ associer patient
       </div>
       {% endif %}
     </div>
+    {% endif %}
 
     <div class="form-row align-items-center">
 

--- a/templates/base/univtags/univTagsConfig.html.twig
+++ b/templates/base/univtags/univTagsConfig.html.twig
@@ -1,0 +1,82 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2021      DEMAREST Maxime <maxime@indelog.fr>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > Config : template pour la page de gestion des tags universelle
+ #
+ # @author DEMAREST Maxime <maxime@indelog.fr>
+ #}
+
+{% extends "page.html.twig" %}
+{% block title %}{{ config.designAppName }} : configuration{% endblock %}
+
+{% block head %}
+  {{ parent() }}
+  <script defer src="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/js/configuration.js?{{ modules.base }}"></script>
+  <script defer src="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/js/univtags/config.js?{{ modules.base }}"></script>
+{% endblock %}
+
+{% block body %}
+
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <a href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/configuration/">Configuration</a>
+    </li>
+    <li class="breadcrumb-item">
+      <a href="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/configuration/#cc">Paramètres courants</a>
+    </li>
+  </ol>
+
+  <h1>Configuration de l'étiquetage universel</h1>
+
+  <table class="table table-sm mb-0 table-striped">
+    <thead>
+      <tr>
+        <th></th>
+        <th>#ID</th>
+        <th>Nom</th>
+        <th>Description</th>
+        <th>Actif</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% if page.univTagsTypeList is empty %}
+        <tr class="table-danger"><td colspan="5">Aucun type d'étiquette n'a été trouvé. Cela peut venir d'une erreur SQL ou d'une absence de type d'étiquette en base.</td></tr>
+      {% else %}
+        {% for type in page.univTagsTypeList %}
+          <tr class="table-primary univTagsTableLineType" data-typeID="{{ type.id }}" onmouseout="this.classList.replace('table-active','table-primary')" onmouseover="this.classList.replace('table-primary','table-active')">
+            <td class="unviTagsTypeShowIndicator" data-typeID="{{ type.id }}" data-showed="false" onclick="univTagsGetList({{ type.id }}, this)">
+                <span class="far fa-plus-square" data-typeID="{{ type.id }}"></span>
+                <span class="far fa-minus-square d-none" data-typeID="{{ type.id }}"></span>
+            </td>
+            <td>#{{ type.id }}</td>
+            <td>{{ type.name }}</td>
+            <td>{{ type.description }}</td>
+            <td class="text-center">
+                <input type="checkbox" name="activeUnivtagType[{{ type.id }}]" data-id="{{ type.id }}" class="chkbx-active-univtag-type" {% if type.actif == '1' %}checked{% endif %} value="{{ type.actif }}" autocomplete="off" onclick="univTagsConfigSetTypeActif({{ type.id }}, this)">
+            </td>
+          </tr>
+          <tr><td class="univTagsContainer d-none" data-typeID="{{ type.id }}" colspan="5"></td></tr>
+        {% endfor %}
+      {% endif %}
+    </tbody>
+  </table>
+
+{% endblock %}

--- a/templates/base/univtags/univTagsTagModal.html.twig
+++ b/templates/base/univtags/univTagsTagModal.html.twig
@@ -1,0 +1,72 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2021      DEMAREST Maxime <maxime@indelog.fr>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > Config : Modal pour la création et la modificaton des tags universelle
+ #
+ # @author DEMAREST Maxime <maxime@indelog.fr>
+ #}
+
+<div id="modalUnivTag" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+
+    <form id="formUnivTag" method="POST" action="">
+      <input type="hidden" name="id" value="{{ page.univTags.tagID }}">
+      <input type="hidden" name="typeID" value="{{ page.univTags.typeID }}">
+      <input type="hidden" name="toID" value="{{ page.univTags.toID }}">
+      <input type="hidden" name="contexte" value="{{ page.univTags.contexte }}">
+      <div class="modal-content">
+
+        <div class="modal-header">
+          {% if page.univTags.tagID > 0 %}
+              <h5 class="modal-title">Modification de l'étiquette</h5>
+          {% else %}
+              <h5 class="modal-title">Nouvelle étiquette {{ page.univTags.typeName }}</h5>
+          {% endif %}
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        </div>
+
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="font-weight-bold">Nom</label>
+            <input name="name" type="text" class="form-control" placeholder="Nom du tag.." title="Nom de l'étiquette..." required="required" maxlength="64" value="{{ page.univTags.tagProp.name|default('') }}" {{ page.univTags.typeDroitCreSup ? '' : 'disabled' }}>
+          </div>
+          <div class="form-group">
+            <label class="font-weight-bold">Déscription</label>
+            <input name="description" type="text" class="form-control" placeholder="Déscription pour le Tag..." title="Déscription de l'étiquette..." required="required" maxlength="64" value="{{ page.univTags.tagProp.description|default('') }}" {{ page.univTags.typeDroitCreSup ? '' : 'disabled' }}>
+          </div>
+          <div class="form-group ">
+            <label class="font-weight-bold">Couleur</label>
+            <input name="color" type="color" value="{{ page.univTags.tagProp.color|default('#B6B6B6') }}" class="form-control" autocomplete="off" {{ page.univTags.typeDroitCreSup ? '' : 'disabled' }}>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          {% if page.univTags.tagID %}
+              <button type="button" class="btn btn-danger" title="Suprime cette étiquette" onclick="formUnivTagValid(this, 1) "{{ page.univTags.typeDroitCreSup ? '' : 'disabled' }}>Suprimer</button>
+          {% endif %}
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Abandoner</button>
+          <button type="button" class="btn btn-primary" onclick="formUnivTagValid(this)" {{ page.univTags.typeDroitCreSup ? '' : 'disabled' }}>Valider</button>
+        </div>
+    
+      </div>
+    </form>
+  </div>
+</div>

--- a/templates/base/univtags/unviTagsTagListe.html.twig
+++ b/templates/base/univtags/unviTagsTagListe.html.twig
@@ -1,0 +1,51 @@
+{#
+ # This file is part of MedShakeEHR.
+ #
+ # Copyright (c) 2021      DEMAREST Maxime <maxime@indelog.fr>
+ # http://www.medshake.net
+ #
+ # MedShakeEHR is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # any later version.
+ #
+ # MedShakeEHR is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with MedShakeEHR.  If not, see <http://www.gnu.org/licenses/>.
+ #/
+
+/##
+ # Template > Config : template pour la page de gestion des tags universelle
+ #
+ # @author DEMAREST Maxime <maxime@indelog.fr>
+ #}
+
+<div class="univTagsTagListe d-flex flex-row flex-wrap" data-typeID="{{ page.univTags.typeID }}" data-contexte="{{ page.univTags.contexte }}">
+{% if page.univTags.tagListe is empty %}
+  <div class="m-2 p-2 font-weight-bold">Aucune étiquette trouvée</div>
+{% else %}
+  {% for tag in page.univTags.tagListe %}
+    <div class="univTagsTag m-1 py-1 px-2 font-weight-bold small font-weight-bold" data-id="{{ tag.id }}" title="{{ tag.description }}" style="color:{{ tag.textcolor }}; background-color:{{ tag.color }};">
+    <span>{{ tag.name }}</span>
+    {% if page.univTags.showEditBtn %}
+      <button type="button" class="univTagsTagEditBtn fas fa-pencil-alt ml-1" title="Modifier cette étiquette" data-typeID="{{ tag.typeID }}" data-tagID="{{ tag.id }}" data-toID="{{ page.univTags.toID }}" onclick="getModalUnivTag({{ page.univTags.typeID }}, {{ tag.id }}, {{ page.univTags.toID }}, '{{ page.univTags.contexte }}');"></button>
+    {% endif %}
+    {% if page.univTags.showSelectSetTo %}
+      <input class="ml-1" type="checkbox" data-tagID="{{ tag.id }}" title="Ajouter ou retirer l'étiquette" data-toID="{{ page.univTags.toID }}"{% if tag.toID == page.univTags.toID %}checked="checked"{% endif %} onchange="univTagsSetTo(this)">
+    {% endif %}
+    {% if page.univTags.showSelectFilterSearch %}
+      <input class="univTagsSelectFilter ml-1" type="checkbox" title="Filtrer les résultat de la recherche avec cette étiquette" name="univtag[{{ tag.id }}]" value="{{ tag.id }}" onchange="updateListingPatients()">
+    {% endif %}
+    </div>
+  {% endfor %}
+{% endif %}
+{% if page.univTags.showNewBtn %}
+<div class="mt-1 ml-2">
+  <button type="button" class="univTagsNewTag btn btn-primary btn-sm" data-typeID="{{ type.id }}" data-tagID="0" data-toID="0" data-contexte="{{ page.univTags.contexte }}" onclick="getModalUnivTag({{ page.univTags.typeID }}, 0, {{ page.univTags.toID }}, '{{ page.univTags.contexte }}')" title="Créer une nouvelle étiquette {{ type.name }}"><span class="univTagsNewTag fa fa-plus mr-1"></span>Ajouter</button>
+</div>
+{% endif %}
+</div>

--- a/upgrade/base/sqlInstall.sql
+++ b/upgrade/base/sqlInstall.sql
@@ -380,7 +380,8 @@ CREATE TABLE IF NOT EXISTS `univtags_tag` (
 	`description` VARCHAR(256),
 	`color` VARCHAR(7) NOT NULL DEFAULT '#B6B6B6',
 	PRIMARY KEY (`id`),
-	KEY `typeID` (`typeID`)
+	KEY `typeID` (`typeID`),
+	CONSTRAINT UniqUnivTagTypeName UNIQUE(`typeID`, `name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 -- Création de la table pour les type de tags

--- a/upgrade/base/sqlUpgrade_v7.1.1_v7.1.2.sql
+++ b/upgrade/base/sqlUpgrade_v7.1.1_v7.1.2.sql
@@ -1,0 +1,52 @@
+-- Mise à jour n° de version
+UPDATE `system` SET `value`='v7.1.2' WHERE `name`='base' and `groupe`='module';
+
+---------------------------
+-- Ajout du système de tags
+---------------------------
+
+-- Création de la table tags
+CREATE TABLE IF NOT EXISTS `univtags_tag` (
+	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`typeID` INT UNSIGNED NOT NULL,
+	`name` VARCHAR(64) NOT NULL,
+	`description` VARCHAR(256),
+	`color` VARCHAR(7) NOT NULL DEFAULT '#B6B6B6',
+	PRIMARY KEY (`id`),
+	KEY `typeID` (`typeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+-- Création de la table pour les type de tags
+CREATE TABLE IF NOT EXISTS `univtags_type` (
+	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`name` VARCHAR(64) NOT NULL,
+	`description` VARCHAR(255) NOT NULL,
+	`actif` BOOLEAN NOT NULL DEFAULT true,
+	`droitCreSup` VARCHAR(128) NOT NULL,
+	`droitAjoRet` VARCHAR(128) NOT NULL,
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `name` (`name`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+-- Table de jointure tags <->  patient (tags pour un dossier médical)
+CREATE TABLE IF NOT EXISTS `univtags_join` (
+	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`tagID` INT NOT NULL,
+	`toID` INT NOT NULL,
+	PRIMARY KEY (`id`),
+	KEY `tagID` (`tagID`),
+	KEY `toID` (`toID`),
+	CONSTRAINT UniqUnivTagsJoin UNIQUE(`tagID`, `toID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+-- Ajoute le type de tag pour le dossier patient
+INSERT IGNORE INTO `univtags_type` (`name`, `description`, `droitCreSup`, `droitAjoRet`) VALUES ('patients', 'Étiquettes pour catégoriser le dossier médical d\'un patient', 'droitUnivTagPatientPeutCreerSuprimer', 'droitUnivTagPatientPeutAjouterRetirer');
+INSERT IGNORE INTO `univtags_type` (`name`, `description`, `droitCreSup`, `droitAjoRet`) VALUES ('pros', 'Étiquettes pour catégoriser un fiche pro.', 'droitUnivTagProPeutCreerSuprimer', 'droitUnivTagProPeutAjouterRetirer');
+
+-- Ajoute de nouvelle option de de configuration pour les tags universelle
+INSERT IGNORE INTO `configuration` (`name`, `level`, `toID`, `module`, `cat`, `type`, `description`, `value`) VALUES
+('optionGeActiverUnivTags', 'default', '0', '', 'Activation services', 'true/false', 'activier / désactiver l\'utilisation des tags universel', 'true'),
+('droitUnivTagPatientPeutAjouterRetirer', 'default', '0', '', 'Droits', 'true/false', 'peut ajouter ou retirer une étiquette sur un dossier patient', 'true'),
+('droitUnivTagPatientPeutCreerSuprimer', 'default', '0', '', 'Droits', 'true/false', 'peut créer et supprimer des étiquettes pour les dossier patients', 'true'),
+('droitUnivTagProPeutAjouterRetirer', 'default', '0', '', 'Droits', 'true/false', 'peut ajouter ou retirer une étiquette sur un pro', 'true'),
+('droitUnivTagProPeutCreerSuprimer', 'default', '0', '', 'Droits', 'true/false', 'peut créer et supprimer des étiquettes pour les pro', 'true');

--- a/upgrade/base/sqlUpgrade_v7.1.1_v7.1.2.sql
+++ b/upgrade/base/sqlUpgrade_v7.1.1_v7.1.2.sql
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS `univtags_tag` (
 	`description` VARCHAR(256),
 	`color` VARCHAR(7) NOT NULL DEFAULT '#B6B6B6',
 	PRIMARY KEY (`id`),
-	KEY `typeID` (`typeID`)
+	KEY `typeID` (`typeID`),
+	CONSTRAINT UniqUnivTagTypeName UNIQUE(`typeID`, `name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 -- Création de la table pour les type de tags


### PR DESCRIPTION
Feat ajout de la fonctionnalité de tag universel
    
Les tags universel permettent de disposer d'une fonctionnalité d'étiquetage
commune à tout les éléments de MedShakeEHR qui soit la plus indépendante
possible des éléments étiquetés et la plus facilement réutilisable dans
différents contexte.
    
L'étiquetage doit permettre de classer et regrouper simplement des
éléments. Si l'élément dispose de fonctions de recherche les étiquettes peuvent
être utilisé pour filtrer les résultats le recherche.
    
A la base, différent type de tags sont définit. Chaque type doit
correspondre à un élément dans MedShakeEHR (sont implémentés dans la version
actuel un type pour les patient et un autre pour les pro, d’autres type peuvent
facilement être implémenté comme pour les élément de l'agenda). Chaque type
peut être activé ou désactivé indépendamment des autres. Chaque type peut
définir ses propre droits sous forme de paramètre de configuration afin de
déterminer si un utilisateur peut créer, modifier et supprimer des tags pour un
type donnée ou bien ajouté des tags du type sur un élément. Le tout étant pensé
pour des module ou plugin externe puissent facilement intégrer les tags
universel.
