### PR TITLE
Feat : filtrer nom prénom sur recherche patient agenda 

### DIFF
--- a/controlers/agenda/actions/inc-ajax-searchPatient.php
+++ b/controlers/agenda/actions/inc-ajax-searchPatient.php
@@ -34,7 +34,7 @@ $a_json = array();
 // prénoms très commun :
 //   (ex : MARIE Françoise (nom + prenom) <> Marie Françoise (prénom seul))
 // en donnant le prossiblité de préciser la recherche en spéparant les nom et
-// prénom par un "|". Dans le cas le nom est le premier terme et le prénom le
+// prénom par un ":". Dans le cas le nom est le premier terme et le prénom le
 // second.
 $split_term = explode(':', $term);
 if (count($split_term) > 1) {


### PR DESCRIPTION
La recherche rapide de patient sur la page de l'agenda peut sur une
grosse base de donné patient et dans certain cas être impossible. Cela
peut arrivé si le couple nom prénom d'un patient ressemble à un prénom
très utilisé (ex : MARIE Françoise (nom + prénom) <> Marie Françoise (prénom
seul)). Comme le nombre de résultat retrouvé est limité le patient
recherché peut ne jamais apparaître sur la liste.

Ceci permet de contourner le problème en ajoutant la possibilité de
faire une recherche plus fine en séparant le nom et le prénom dans le
champ de recherche avec un caractère ":" (du coup pour rechercher
explicitement le nom "MARIE" et le prénom "Françoise" il suffit saisir
"marie : françoise".