### PR TITLE
fix: composer not supported uppercases anymore

### DIFF
--- a/public_html/composer.json
+++ b/public_html/composer.json
@@ -7,10 +7,10 @@
         {
             "type": "package",
             "package": {
-                "name": "mattbryson/TouchSwipe-Jquery-Plugin",
+                "name": "mattbryson/touchswipe-jquery-plugin",
                 "version": "1.6.18",
                 "source": {
-                    "url": "https://github.com/mattbryson/TouchSwipe-Jquery-Plugin.git",
+                    "url": "https://github.com/mattbryson/touchswipe-jquery-plugin.git",
                     "type": "git",
                     "reference": "1.6.18"
                 }
@@ -19,10 +19,10 @@
         {
             "type": "package",
             "package": {
-                "name": "FezVrasta/popper.js",
+                "name": "fezvrasta/popper.js",
                 "version": "v1.14.4",
                 "source": {
-                    "url": "https://github.com/FezVrasta/popper.js.git",
+                    "url": "https://github.com/fezvrasta/popper.js.git",
                     "type": "git",
                     "reference": "v1.14.4"
                 }
@@ -31,10 +31,10 @@
         {
             "type": "package",
             "package": {
-                "name": "dennyferra/TypeWatch",
+                "name": "dennyferra/typewatch",
                 "version": "3.0.0",
                 "source": {
-                    "url": "https://github.com/dennyferra/TypeWatch.git",
+                    "url": "https://github.com/dennyferra/typewatch.git",
                     "type": "git",
                     "reference": "3.0.0"
                 }
@@ -128,11 +128,11 @@
             "type": "package",
             "package": {
                 "name": "fr33z00/panzoom",
-                "version": "v3.2.2.1+1Touch",
+                "version": "v3.2.2.1+1touch",
                 "source": {
                     "url": "https://github.com/fr33z00/jquery.panzoom.git",
                     "type": "git",
-                    "reference": "v3.2.2.1+1Touch"
+                    "reference": "v3.2.2.1+1touch"
                 }
             }
         },
@@ -184,6 +184,6 @@
         "joequery/stupid-table-plugin": "1.1.3",
         "thebingservices/codemirror": "v5.10.0",
         "fortawesome/font-awesome": "^5.13",
-        "fr33z00/panzoom": "v3.2.2.1+1Touch"
+        "fr33z00/panzoom": "v3.2.2.1+1touch"
     }
 }


### PR DESCRIPTION
La nouvelle version de composer ne supporte plus les majuscules dans le composer.json et renvoie une erreur 