### PR TITLE
Fix [APICRYPT] : Identifie les messages avec entêtte HPRIM invalide

### DIFF
--- a/class/msHprim.php
+++ b/class/msHprim.php
@@ -97,6 +97,88 @@ class msHprim
         }
     }
 
+  /**
+   * Tenter de trouver si un message contient un entête HPRIM valide a moyens
+   * de plusieurs test.
+   * @param  $array   Tableau contenant les entêtes hprim d'un message
+   *                  obtenus avec self::getHprimHeaderData()
+   * @return bool     `true` si ça resemble à une entête hprim, sinon `false`
+   * @see    self::getHprimHeaderData()
+   */
+  public static function checkIfValidHprimHeaderData(array $hprim_data) {
+      /**
+       * Ce système est une ébauche...
+       * Chaque test permet d'ajouteur et de retirer un certain nombre de
+       * point sur un score total qui permet de définir si un message contient
+       * une entête hprim ou non.
+       */
+      $score = 0;
+      $score_min  = 10;
+      // Les score pour les tests sont évaluer au doit mouillé et devrons
+      // sûrement être ajustés.
+
+      // Test si le paramètre codePatient est présent
+      if (!empty($hprim_data['codePatient']) || $hprim_data['codePatient'] != '.') {
+          // Et que le code patient resemble à un code
+          preg_match('/(^[A-z0-9-_\/]*$)/', $hprim_data['codePatient'], $matches);
+          $score += (!empty($matches)) ? 3 : -1;
+      }
+      //var_dump('[codePatient] ' . $hprim_data['codePatient'] . ': ' . $score);
+
+      // TEST Si les nom et prénon sont présent
+      $score += (!empty($hprim_data['nom'])) ? +1 : -1;
+      //var_dump('[nom] ' . $hprim_data['nom'] . ': ' . $score);
+      $score += (!empty($hprim_data['prenom'])) ? +1 : -1;
+      //var_dump('[prenom] ' . $hprim_data['prenom'] . ': ' . $score);
+
+
+      // Test si le code postal ressemble à un code postal si il est présent
+      // TODO : Attention, seul les codes postaux français sont pris en compte
+      //        (d'ou le score de 1)
+      if  (!empty($hprim_data['cp']) || $hprim_data['cp'] != '.') {
+          preg_match('/(^[0-9]{1}[1-9]{1}[0-9]{3}$)/', $hprim_data['cp'], $matches);
+          $score += (!empty($matches)) ? 1 : -1;
+      }
+      //var_dump('[cp] ' . $hprim_data['cp'] . ' : ' . $score);
+
+      // Test si la date de naissance est saisis et si c'est le cas, test is
+      // elle est vallide
+      if (!empty($hprim_data['ddn']) || $hprim_data['ddn'] != '.') {
+          // TODO : Est-il sûre que la date soit toujours au format 'd/m/Y' ?
+          $test_date = DateTime::createFromFormat('d/m/Y', $hprim_data['ddn']);
+          if ($test_date && $test_date->format('d/m/Y') == $hprim_data['ddn']) {
+              $score += 8;
+          } else {
+              $score -= 8;
+          }
+      }
+      //var_dump('[ddn] ' . $hprim_data['ddn'] . ' : ' . $score);
+
+
+      // Si il y a un nss saisis, test si celluis ci possède un format valide
+      if (!empty($hprim_data['nss']) || $hprim_data['nss'] != '.') {
+          preg_match('/(^[123478]{1}[0-9]{2}[01]{1}[0-9]{1}[0-9]{1}[0-9AB]{1}[0-9]{6}[0-9]{0,2}$)/', $hprim_data['nss'], $matches);
+          $score += (!empty($matches)) ? 3 : -3;
+      }
+      //var_dump('[nss] ' . $hprim_data['nss'] . ' : ' . $score);
+
+      // Test si la date d'expédition du dossier est présente est si c'est le
+      // cas, test si elle est valide.
+      if (!empty($hprim_data['dateDossier']) || $hprim_data['dateDossier'] != '.') {
+          // TODO : Est-il sûre que la date soit toujours au format 'd/m/Y' ?
+          $test_date = DateTime::createFromFormat('d/m/Y', $hprim_data['dateDossier']);
+          if ($test_date && $test_date->format('d/m/Y') == $hprim_data['dateDossier']) {
+              $score += 4;
+          } else {
+              $score -= 4;
+          }
+      }
+      //var_dump('[dateDossier] ' . $hprim_data['dateDossier'] . ' : ' . $score);
+
+      //var_dump($score);
+      return ($score >= $score_min) ? true : false;
+  }
+
 /**
  * Parser en-tête HPRIM d'un fichier txt
  * @param  string $file fichier avec chemin complet

--- a/class/msHprim.php
+++ b/class/msHprim.php
@@ -224,7 +224,13 @@ class msHprim
               break;
 
               case "7":
-              $d['ddn'] = fgets($file);
+              $d['ddn'] = trim(fgets($file));
+              $test_date = DateTime::createFromFormat('Y-m-d', $d['ddn']);
+              // Si date fournis au format Y-m-d, la convertis au format d/m/Y
+              if ($test_date && $test_date->format('Y-m-d') == $d['ddn']) {
+                  $d['ddn'] = $test_date->format('d/m/Y');
+              }
+
               break;
 
               case "8":
@@ -247,7 +253,13 @@ class msHprim
               break;
 
               case "10":
-              $d['dateDossier'] = substr(fgets($file), 0, 15);
+              $d['dateDossier'] = trim(substr(fgets($file), 0, 15));
+              $test_date = DateTime::createFromFormat('Y-m-d', $d['dateDossier']);
+              // Si date fournis au format Y-m-d, la convertis au format d/m/Y
+              if ($test_date && $test_date->format('Y-m-d') == $d['dateDossier']) {
+                  $d['dateDossier'] = $test_date->format('d/m/Y');
+              }
+
               break;
 
               case "11":

--- a/controlers/inbox/actions/inc-ajax-viewMail.php
+++ b/controlers/inbox/actions/inc-ajax-viewMail.php
@@ -33,6 +33,7 @@ if(!is_numeric($_POST['mailID'])) die;
 
 $p['page']['mail']=msSQL::sqlUnique("select id, txtFileName, mailHeaderInfos, txtDatetime, hprimExpediteur, hprimAllSerialize, pjNombre, pjSerializeName, archived, assoToID from inbox where id='".$_POST['mailID']."'");
 $p['page']['mail']['hprimAllSerialize']=unserialize($p['page']['mail']['hprimAllSerialize']);
+$p['page']['mail']['isValidHprim'] = msHprim::checkIfValidHprimHeaderData($p['page']['mail']['hprimAllSerialize']);
 $p['page']['mail']['pjSerializeName']=unserialize($p['page']['mail']['pjSerializeName']);
 $p['page']['mail']['mailHeaderInfos']=unserialize($p['page']['mail']['mailHeaderInfos']);
 
@@ -40,7 +41,11 @@ $p['page']['mail']['corps']=msInbox::getMessageBody($p['config']['apicryptChemin
 //hprim
 $p['page']['mail']['bioHprim'] = msHprim::parseSourceHprim($p['page']['mail']['corps']);
 
-$p['page']['mail']['patientsPossibles']=msHprim::getPossiblePatients($p['page']['mail']['hprimAllSerialize'],$p['page']['mail']['assoToID']);
+if ($p['page']['mail']['isValidHprim']) {
+    $p['page']['mail']['patientsPossibles'] = msHprim::getPossiblePatients($p['page']['mail']['hprimAllSerialize'],$p['page']['mail']['assoToID']);
+} else {
+    $p['page']['mail']['patientsPossibles'] = array();
+}
 
 $p['page']['mail']['relativePathForPJ']=str_replace($p['config']['webDirectory'], '', $p['config']['apicryptCheminInbox']);
 

--- a/controlers/inbox/inbox.php
+++ b/controlers/inbox/inbox.php
@@ -43,11 +43,12 @@ if($p['config']['designInboxMailsSortOrder'] == 'asc') {
   $p['page']['sort']='desc';
 }
 
-if ($mails=msSQL::sql2tab("select id, txtFileName, DATE_FORMAT(txtDatetime, '%Y-%m-%d') as day, hprimIdentite, hprimExpediteur, pjNombre, archived
-from inbox
-where archived!='y' and mailForUserID in ('".$apicryptInboxMailForUserID."')
-order by txtDatetime ".$p['page']['sort'].", txtNumOrdre ".$p['page']['sort'])) {
+if ($mails=msSQL::sql2tab("select id, txtFileName, DATE_FORMAT(txtDatetime, '%Y-%m-%d') as day, hprimIdentite, hprimExpediteur, hprimAllSerialize, pjNombre, archived
+    from inbox
+    where archived!='y' and mailForUserID in ('".$apicryptInboxMailForUserID."')
+    order by txtDatetime ".$p['page']['sort'].", txtNumOrdre ".$p['page']['sort'])) {
     foreach ($mails as $mail) {
-        $p['page']['inbox']['mails'][$mail['day']][]=$mail;
+        $mail['isValidHprim'] = msHprim::checkIfValidHprimHeaderData(unserialize($mail['hprimAllSerialize']));
+        $p['page']['inbox']['mails'][$mail['day']][] = $mail;
     }
 }

--- a/templates/base/inbox/inbox.html.twig
+++ b/templates/base/inbox/inbox.html.twig
@@ -93,7 +93,7 @@
             </tr>
             {% for mail in mails %}
               <tr class="small mailClicView{% if parentLoop == '1' and loop.index == '1' %} table-success{% elseif mail.archived == 'c' %} table-warning{% endif %}" data-mailid="{{ mail.id }}" data-status="{{ mail.archived }}">
-                {% if mail.hprimIdentite %}
+                {% if mail.isValidHprim %}
                   <td class="font-weight-bold">
                     {{ mail.hprimIdentite|e }}
                   </td>

--- a/templates/base/inbox/mailView.html.twig
+++ b/templates/base/inbox/mailView.html.twig
@@ -67,37 +67,43 @@
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <th>HPRIM</th>
-                    <td>{{ page.mail.hprimAllSerialize.nom|e }}</td>
-                    <td>{{ page.mail.hprimAllSerialize.prenom|e }}</td>
-                    <td>{{ page.mail.hprimAllSerialize.ddn|e }}</td>
-                    <td>
-                        <small>{{ page.mail.hprimAllSerialize.adresse1 }}
-                            {% if page.mail.hprimAllSerialize.adresse2 != page.mail.hprimAllSerialize.adresse1 and page.mail.hprimAllSerialize.adresse2 %}
-                                {{ page.mail.hprimAllSerialize.adresse2 }}
-                            {% endif %}
-                            {{ page.mail.hprimAllSerialize.cp|e }}
-                            {{ page.mail.hprimAllSerialize.ville|e }}</small>
-                    </td>
-                    <td>
-                        <small>{{ page.mail.hprimAllSerialize.nss|e }}</small>
-                    </td>
-                    <td>
-                      <form class="d-inline" action="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/patient/create/" method="post" target="_blank">
-                        <input type="hidden" name="birthname" value="{{ page.mail.hprimAllSerialize.nom|e }}">
-                        <input type="hidden" name="firstname" value="{{ page.mail.hprimAllSerialize.prenom|e }}">
-                        <input type="hidden" name="birthdate" value="{{ page.mail.hprimAllSerialize.ddn|e }}">
-                        <input type="hidden" name="postalCodePerso" value="{{ page.mail.hprimAllSerialize.cp|e }}">
-                        <input type="hidden" name="street" value="{{ page.mail.hprimAllSerialize.street|e }}">
-                        <input type="hidden" name="streetNumber" value="{{ page.mail.hprimAllSerialize.streetNumber|e }}">
-                        <input type="hidden" name="city" value="{{ page.mail.hprimAllSerialize.ville|e }}">
-                        <input type="hidden" name="nss" value="{{ page.mail.hprimAllSerialize.nss|e }}">
-                        <input type="hidden" name="administrativeGenderCode" value="{{ page.mail.hprimAllSerialize.administrativeGenderCode|e }}">
-                        <button type="submit" class="btn btn-sm btn-light" title="Créer le dossier"><i class="fas fa-user-plus"></i></button>
-                      </form>
-                    </td>
-                </tr>
+                {% if page.mail.isValidHprim %}
+                    <tr>
+                        <th>HPRIM</th>
+                        <td>{{ page.mail.hprimAllSerialize.nom|e }}</td>
+                        <td>{{ page.mail.hprimAllSerialize.prenom|e }}</td>
+                        <td>{{ page.mail.hprimAllSerialize.ddn|e }}</td>
+                        <td>
+                            <small>{{ page.mail.hprimAllSerialize.adresse1 }}
+                                {% if page.mail.hprimAllSerialize.adresse2 != page.mail.hprimAllSerialize.adresse1 and page.mail.hprimAllSerialize.adresse2 %}
+                                    {{ page.mail.hprimAllSerialize.adresse2 }}
+                                {% endif %}
+                                {{ page.mail.hprimAllSerialize.cp|e }}
+                                {{ page.mail.hprimAllSerialize.ville|e }}</small>
+                        </td>
+                        <td>
+                            <small>{{ page.mail.hprimAllSerialize.nss|e }}</small>
+                        </td>
+                        <td>
+                          <form class="d-inline" action="{{ config.protocol }}{{ config.host }}{{ config.urlHostSuffixe }}/patient/create/" method="post" target="_blank">
+                            <input type="hidden" name="birthname" value="{{ page.mail.hprimAllSerialize.nom|e }}">
+                            <input type="hidden" name="firstname" value="{{ page.mail.hprimAllSerialize.prenom|e }}">
+                            <input type="hidden" name="birthdate" value="{{ page.mail.hprimAllSerialize.ddn|e }}">
+                            <input type="hidden" name="postalCodePerso" value="{{ page.mail.hprimAllSerialize.cp|e }}">
+                            <input type="hidden" name="street" value="{{ page.mail.hprimAllSerialize.street|e }}">
+                            <input type="hidden" name="streetNumber" value="{{ page.mail.hprimAllSerialize.streetNumber|e }}">
+                            <input type="hidden" name="city" value="{{ page.mail.hprimAllSerialize.ville|e }}">
+                            <input type="hidden" name="nss" value="{{ page.mail.hprimAllSerialize.nss|e }}">
+                            <input type="hidden" name="administrativeGenderCode" value="{{ page.mail.hprimAllSerialize.administrativeGenderCode|e }}">
+                            <button type="submit" class="btn btn-sm btn-light" title="Créer le dossier"><i class="fas fa-user-plus"></i></button>
+                          </form>
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <th colspan="7">- message sans données HPRIM -</th>
+                    </tr>
+                {% endif %}
                 {% for k, v in page.mail.patientsPossibles %}
 
                     <tr class="patietSelect {% if loop.index0 == 0 %} table-success gras{% endif %}" data-patientID="{{ v.id }}" {% if v.patientType == 'deleted' %}style="text-decoration: line-through"{% endif %}>


### PR DESCRIPTION
Maintenant qu'APICRYPT peut recevoir des messages de la part de MsSanté,
il est possible d'en recevoir qui ne possède pas d'entête
HPRIM. Ajoute un moyen de vérifier si le message possède bien une entête
HPRIM valide et si ce n'est pas le cas, indique que le message n'en
possède pas plutôt que de tenter d'afficher des informations
incohérentes.

### NOTE : 
La méthode `msHprim::checkIfValidHprimHeaderData()` peut être grandement
amélioré. J'ai essayé de mettre en place un système de score pour évaluer si
le message possède bien un entête HPRIM valide ou non mais c'est très simpliste
(et je manque d'échantillon de message pour tester sur de nombreux cas de
figure). Pour faire simple le message doit avoir un score de 10 pour considérer
qu'il possède une entête HPRIM valide. Des tests sont passés sur les diverses
Éléments de l'entête et en fonction de si le test réussi ou non le score est
incrémenté ou décrémenté. Par exemple, s'il y a une valeur non null pour la
date de naissance on teste si c'est bien une date valide. Si c'est le cas, le
score augmente sinon il diminue. Une absence de valeur ne change pas le score.
Normalement, un message qui possède une valeur pour le nom et le prénom ainsi
qu'une date de naissance valide obtiens 10 s'il n'a pas d'autres champs avec
des erreurs (comme un numéro de sécurité social ou un code postal invalide).

Bref, a tester...
