### PR TITLE
fix: error message on chromium based browser

### DIFF
--- a/installer/debian-bash-installer.sh
+++ b/installer/debian-bash-installer.sh
@@ -94,9 +94,7 @@ selectdomain() {
 certGen() {
     mkdir /etc/ssl/$msehrDom
     cd /etc/ssl/$msehrDom
-    openssl genrsa -out $msehrDom.key 4096
-    openssl req -new -key $msehrDom.key -out $msehrDom.csr
-    openssl x509 -req -days 3650 -in $msehrDom.csr -signkey $msehrDom.key -out $msehrDom.pem
+    openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout $msehrDom.key -out $msehrDom.crt -subj "/CN=$msehrDom" -addext "subjectAltName=DNS:$msehrDom"
 }
 
 apacheConfig() {
@@ -113,7 +111,7 @@ apacheConfig() {
         DocumentRoot "$msehrPath/public_html"
         RewriteEngine On
         SSLEngine On
-        SSLCertificateFile /etc/ssl/$msehrDom/$msehrDom.pem
+        SSLCertificateFile /etc/ssl/$msehrDom/$msehrDom.crt
         SSLCertificateKeyFile /etc/ssl/$msehrDom/$msehrDom.key
         <Directory "$msehrPath/public_html">
             Options FollowSymLinks


### PR DESCRIPTION
Modification de la génération du certificat en auto-signé SAN pour pouvoir valider l'autorité de certification sur les navigateurs basés sur Chromium