### PR TITLE
fix: dompdf php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "altorouter/altorouter": "2.0.1",
     "mustangostang/spyc": "0.6.3",
     "wixel/gump": "1.5.7",
-    "dompdf/dompdf": "0.8.5",
+    "dompdf/dompdf": "2.0.0",
     "phpmailer/phpmailer": "6.5.1",
     "atrapalo/urlcrypt": "1.0.1",
     "webit/eval-math": "1.0.1",


### PR DESCRIPTION
Enlève le message d'erreur de composer pour dompdf. J'ai testé le changement sur des factures et dossiers ça décale légèrement l'entête. Je ne sais pas s'il y a d'autres fonctions à tester pour s'assurer de la compatibilité