### PR TITLE
fix: php80 CountOnNull

### DIFF
--- a/controlers/index.php
+++ b/controlers/index.php
@@ -34,7 +34,7 @@ if ($p['config']['agendaDistantLink']=='') {
         $agenda->set_userID($p['user']['id']);
     }
     $todays=$agenda->getPatientsOfTheDay();
-    if (count($todays)) {
+    if (is_countable($todays) ? count($todays) : 0) {
         msTools::redirection('/todays/');
     }
 }


### PR DESCRIPTION
fix le bug sur php 8 de l'absence de redirection de localhost vers localhost/patients quand patient today n'est pas configuré
(correction effectuée avec rector après avoir identifié le bon fichier via les logs d'erreurs, testé sur debian sid et ubuntu 22.04 [php8.1])