### PR TITLE
fix: allow-plugin for composer 2.2

### DIFF
--- a/public_html/composer.json
+++ b/public_html/composer.json
@@ -1,6 +1,9 @@
 {
     "config": {
-      "vendor-dir":"thirdparty"
+      "vendor-dir":"thirdparty",
+      "allow-plugins": {
+        "robloach/component-installer": true
+      }
     },
     "repositories": [
 


### PR DESCRIPTION
évite un message d'erreur sur composer 2.2.18 et supérieur