### PR TITLE
fix: path typewatch

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -490,7 +490,7 @@ if (! $iscli) {
       <script defer src="<?=$webpath?>/thirdparty/eonasdan/bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
       <script defer src="<?=$webpath?>/js/jquery-ui-1.12.1.custom/jquery-ui.min.js"></script>
       <script defer src="<?=$webpath?>/js/general.js"></script>
-      <script defer src="<?=$webpath?>/thirdparty/dennyferra/TypeWatch/jquery.typewatch.js"></script>
+      <script defer src="<?=$webpath?>/thirdparty/dennyferra/typewatch/jquery.typewatch.js"></script>
       <script defer src="<?=$webpath?>/thirdparty/danielm/uploader/dist/js/jquery.dm-uploader.min.js"></script>
       <script defer="defer" src="<?=$webpath?>/thirdparty/lrsjng/kjua/dist/kjua.min.js"></script>
 


### PR DESCRIPTION
fix l'url de typewatch depuis la mise à jour de composer. Ne règle pas les 302 sur la racine, et le favicon